### PR TITLE
MGMT-19878: Update control plane status for upgrade

### DIFF
--- a/controlplane/internal/upgrade/mock_upgrade.go
+++ b/controlplane/internal/upgrade/mock_upgrade.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1alpha2 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
 )
 
 // MockClusterUpgradeFactory is a mock of ClusterUpgradeFactory interface.
@@ -134,4 +135,18 @@ func (mr *MockClusterUpgradeMockRecorder) UpdateClusterVersionDesiredUpdate(ctx,
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, desiredVersion}, options...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterVersionDesiredUpdate", reflect.TypeOf((*MockClusterUpgrade)(nil).UpdateClusterVersionDesiredUpdate), varargs...)
+}
+
+// VerifyUpgradedNodes mocks base method.
+func (m *MockClusterUpgrade) VerifyUpgradedNodes(ctx context.Context, oacp *v1alpha2.OpenshiftAssistedControlPlane) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyUpgradedNodes", ctx, oacp)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyUpgradedNodes indicates an expected call of VerifyUpgradedNodes.
+func (mr *MockClusterUpgradeMockRecorder) VerifyUpgradedNodes(ctx, oacp interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUpgradedNodes", reflect.TypeOf((*MockClusterUpgrade)(nil).VerifyUpgradedNodes), ctx, oacp)
 }

--- a/controlplane/internal/upgrade/suite_test.go
+++ b/controlplane/internal/upgrade/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -24,5 +25,5 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	utilruntime.Must(configv1.AddToScheme(testScheme))
-
+	utilruntime.Must(corev1.AddToScheme(testScheme))
 })

--- a/controlplane/internal/workloadclient/workload_client.go
+++ b/controlplane/internal/workloadclient/workload_client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-assisted/cluster-api-agent/util"
 	configv1 "github.com/openshift/api/config/v1"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,9 +37,8 @@ func (w *WorkloadClusterClientGenerator) GetWorkloadClusterClient(kubeconfig []b
 	}
 
 	schemes := runtime.NewScheme()
-	if err := configv1.Install(schemes); err != nil {
-		return nil, err
-	}
+	configv1.AddToScheme(schemes)
+	corev1.AddToScheme(schemes)
 	targetClient, err := client.New(restConfig, client.Options{Scheme: schemes})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Modifies status.ready to false when upgrade starts and changes it back to true when upgrade completes. Modifies updated replicas to the number of control plane nodes that are ready after upgrade completes.
These statuses are checked by Sylva when running an upgrade.