### PR TITLE
NO-ISSUE: Add ansible plays for e2e tests

### DIFF
--- a/test/ansible/README.md
+++ b/test/ansible/README.md
@@ -1,0 +1,31 @@
+# Additional Ansible Plays
+
+## Deploy controllers
+
+`deploy_controllers.yaml` allows for redeploying the OpenShift Agent Control Plane and OpenShift Agent Bootstrap controllers in an already setup test environment. Useful for testing code changes live.
+
+### Usage
+
+```sh
+# Set a container tag that's different from the current deployed tag
+export CONTAINER_TAG=
+
+# Recreate the manifests
+make generate && make manifests && make build-installer
+
+# Run the play to deploy the updated controllers
+ansible-playbook test/ansible/deploy_controllers.yaml -i test/ansible/inventory.yaml
+```
+
+## Environment Cleanup
+
+`cleanup.yaml` will destroy the e2e environment by removing all of the hosts (VMs and network), the sushy tools podman container, and the kind cluster.
+
+### Usage
+
+```sh
+ansible-playbook test/ansible/cleanup.yaml -i test/ansible/inventory.yaml
+```
+
+## Create more hosts
+WIP

--- a/test/ansible/cleanup.yaml
+++ b/test/ansible/cleanup.yaml
@@ -1,0 +1,45 @@
+---
+- name: Cleanup
+  hosts: test_runner
+  vars:
+    remote_manifests_path: /tmp/manifests
+    src_dir: /tmp/capbcoa
+    kind_cluster_name: capi-baremetal-provider
+  tasks:
+  # destroy all VMs
+  - name: Copy VM destruction script
+    copy:
+      dest: "/tmp/vm_functions"
+      content: |
+        #!/bin/bash
+        function destroy_vm {
+          virsh list --all --name | grep bmh-vm | while read vmName ; do  
+            virsh destroy "${vmName}" 2>/dev/null || true
+            virsh undefine --domain "${vmName}" --remove-all-storage --nvram 2>/dev/null || true
+          done
+        }
+        function destroy_volumes {
+          virsh vol-list --pool default | grep -e qcow2 -e img | while read volume ; do
+            volumeName=$(echo volume | awk '{print $1}')
+            virsh vol-delete --pool default $volumeName
+          done
+        }
+
+  - name: destroy vms
+    shell: 'source /tmp/vm_functions && destroy_vm'
+
+  # destroy test libvirt network
+  - name: destroy libvirt network
+    shell: "(virsh net-destroy bmh || true) && (virsh net-undefine bmh || true)"
+
+  # destroy vm volumes
+  - name: destroy libvirt network
+    shell: "(virsh net-destroy bmh || true) && (virsh net-undefine bmh || true)"
+
+  - name: delete sushytools pod
+    shell: podman rm -f sushy-tools
+
+  # remove kind cluster
+  - name: delete kind cluster
+    shell: "kind delete cluster --name {{ kind_cluster_name }}"
+

--- a/test/ansible/deploy_controllers.yaml
+++ b/test/ansible/deploy_controllers.yaml
@@ -1,0 +1,38 @@
+---
+- name: Setup and run controllers
+  hosts: test_runner
+  vars:
+    dist_dir: "{{ lookup('ansible.builtin.env', 'DIST_DIR') }}"
+    src_dir: /tmp/capbcoa
+    kind_cluster_name: capi-baremetal-provider
+    container_tag: "{{ lookup('ansible.builtin.env', 'CONTAINER_TAG') }}"
+  tasks:
+
+  - name: copy src
+    synchronize:
+      src: ../../../
+      dest: "{{ src_dir }}"
+      archive: true
+      recursive: true
+
+  - name: build images
+    shell: "export CONTAINER_TAG={{ container_tag }} && cd {{ src_dir }} && setsid make docker-build-all"
+
+  - name: load images into kind
+    shell: "podman save quay.io/edge-infrastructure/openshift-capi-agent-{{ item }}:{{ container_tag }} > {{ item }}.tar.gz && kind load image-archive --name {{ kind_cluster_name }} {{ item }}.tar.gz"
+    loop:
+      - controlplane
+      - bootstrap
+
+  # files generated before ansible
+  - name: copy distfiles
+    copy:
+      src: "{{ dist_dir }}"
+      dest: "/tmp"
+  
+  - name: set imagePullPolicy CAPBCOA
+    shell: "cat /tmp/dist/bootstrap_install.yaml | sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' > /tmp/bootstrap_install.yaml && cat /tmp/dist/controlplane_install.yaml | sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' > /tmp/controlplane_install.yaml"
+
+  - name: deploy CAPBCOA
+    shell: kubectl apply -f /tmp/controlplane_install.yaml && kubectl apply -f /tmp/bootstrap_install.yaml
+

--- a/test/ansible/hosts.yaml
+++ b/test/ansible/hosts.yaml
@@ -1,0 +1,91 @@
+---
+- name: Deploy Hosts
+  hosts: test_runner
+  vars:
+    remote_manifests_path: /tmp/manifests
+    test_namespace: test-capi
+    number_of_nodes: "{{ lookup('ansible.builtin.env', 'NUMBER_OF_NODES', default='5') }}"
+
+    capi_version: v1.7.1
+    capm3_version: v1.6.0
+    dist_dir: "{{ lookup('ansible.builtin.env', 'DIST_DIR') }}"
+    src_dir: /tmp/capbcoa
+    kind_cluster_name: capi-baremetal-provider
+    ssh_authorized_key: "{{ lookup('ansible.builtin.env', 'SSH_AUTHORIZED_KEY') }}"
+    pullsecret: "{{ lookup('ansible.builtin.env', 'PULLSECRET') }}"
+  tasks:
+  - name: copy src
+    synchronize:
+      src: ../../../
+      dest: "{{ src_dir }}"
+      archive: true
+      recursive: true
+
+  - name: Escape SSH auth
+    shell: echo {{ ssh_authorized_key }} | sed 's/\ /\\ /g'
+    register: ssh_authorized_key
+
+  # files generated before ansible
+  - name: copy distfiles
+    copy:
+      src: "{{ dist_dir }}"
+      dest: "/tmp"
+
+  # setup test env vars
+  - name: Clean current test vars
+    command: rm -rf ~/.test-config
+
+  - name: Define SSH_AUTHORIZED_KEY
+    lineinfile:
+      path: ~/.test-config
+      line: "export SSH_AUTHORIZED_KEY='{{ ssh_authorized_key }}'"
+      create: true
+      state: present
+
+  - name: Define PULLSECRET
+    lineinfile:
+      path: ~/.test-config
+      line: "export PULLSECRET='{{ pullsecret }}'"
+      create: true
+      state: present
+
+  - name: Copy VM creation script
+    copy:
+      dest: "/tmp/vm_functions"
+      content: |
+        #!/bin/bash
+        function create_vm {
+          name=$1
+          mac=$2
+          virsh destroy "${name}" 2>/dev/null || true
+          virsh undefine --domain "${name}" --remove-all-storage --nvram 2>/dev/null || true
+          virt-install -n "${name}" --pxe --os-variant=rhel8.0 --ram=16384 --vcpus=8 --network network=bmh,mac="${mac}" --disk size=120,bus=scsi,sparse=yes --check disk_size=off --noautoconsole
+        }
+        function destroy_vm {
+          virsh list --all --name | grep bmh-vm | while read vmName ; do  
+            virsh destroy "${vmName}" 2>/dev/null || true
+            virsh undefine --domain "${vmName}" --remove-all-storage --nvram 2>/dev/null || true
+          done
+        }
+
+  - name: Create BMHs
+    shell: 'source /tmp/vm_functions && create_vm bmh-vm-{{ item }} "00:60:2f:31:81:{{ item }}"'
+    with_sequence: count="{{ number_of_nodes }}" format="%02x"
+
+  # create BMHs
+  - name: Copy BMH creation script
+    copy:
+      dest: "/tmp/create_bmhs"
+      content: |
+        #!/bin/bash
+        i=0
+        for systemid in $(curl -s 192.168.222.1:8000/redfish/v1/Systems | jq -r '.Members[]."@odata.id"'); do
+          echo "starting VM BMH..."
+          i=$((i+1))
+          name=$(curl -s 192.168.222.1:8000${systemid} | jq -r '.Name')
+          sed -r "s%redfish-virtualmedia.*REPLACE_ID%redfish-virtualmedia+http://192.168.222.1:8000${systemid}%" {{ src_dir}}/test/e2e/bmh/bmh.yaml.tpl | sed -r "s/REPLACE_NAME/${name}/g" | sed -r "s/REPLACE_MAC/00:60:2f:31:81:0${name:0-1}/g" | kubectl -n {{ test_namespace }} apply -f -
+          echo "done"
+        done
+
+  - name: create bmhs
+    shell: chmod +x /tmp/create_bmhs && /tmp/create_bmhs


### PR DESCRIPTION
Separates the main play into the following ansible plays for easily running one section of the test:
- cleanup.yaml: cleans up the environment by removing all hosts, vms and the kind cluster
- deploy_controllers.yaml: allows for redeploying the controllers in an already setup test environment. Useful for testing code changes
- hosts.yaml: Creates the host VMs and BMHs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automation playbooks to streamline test environment setup, including controller deployment and host configuration.
	- Added a cleanup process to gracefully dismantle test environments.
- **Documentation**
	- Included detailed instructions and usage examples for the new automation tasks to assist with deployments and cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->