### PR TITLE
add ADR for architectural decision that diverge from CAPI contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Then we can run:
 ansible-playbook test/ansible/run_test.yaml -i test/ansible/inventory.yaml
 ```
 
+## ADRs
+* [001-distribution-version](docs/adr/001-distribution-version.md)
+* [002-distribution-version-upgrades](docs/adr/002-distribution-version-upgrades.md)
+
 ## Contributing
 
 Please, read our [CONTRIBUTING](CONTRIBUTING.md) guidelines for more info about how to create, document, and review PRs.

--- a/docs/adr/001-distribution-version.md
+++ b/docs/adr/001-distribution-version.md
@@ -1,0 +1,21 @@
+# ADR: Handling CAPI Contracts Discrepancy Using distributionVersion
+
+## Status
+
+Proposed
+
+## Context
+
+Cluster API (CAPI) contracts rely heavily on the kubernetesVersion field to define Kubernetes versioning and manage upgrades. However, when dealing with OpenShift, there is no direct one-to-one mapping between the kubernetesVersion and OpenShift’s versioning scheme. Because of this, we had to introduce a custom field named `distributionVersion`.
+
+This discrepancy necessitates an alternative approach to accurately capture the version of the distribution deployed. The introduction of this field allows compatibility with OpenShift’s unique versioning scheme while still adhering to CAPI’s framework as closely as possible. Specifics of this problem are discussed in detail in the upstream issue: [CAPI Issue #11816](https://github.com/kubernetes-sigs/cluster-api/issues/11816).
+
+## Decision
+
+We will introduce the `distributionVersion` field as a custom extension to the relevant CAPI objects, enabling accurate version tracking for OpenShift deployments. The rationale behind this approach is to provide a reliable and consistent way to capture the version information of OpenShift that cannot be represented by kubernetesVersion alone.
+
+## Consequences
+
+- This approach diverges from the CAPI contract but is necessary to support OpenShift versioning.
+- It requires ongoing maintenance of this custom field until it is potentially adopted upstream.
+- Upstream adoption of the `distributionVersion` field would allow for better compatibility and a reduction in discrepancies with CAPI contracts.

--- a/docs/adr/002-distribution-version-upgrades.md
+++ b/docs/adr/002-distribution-version-upgrades.md
@@ -1,0 +1,33 @@
+# ADR: Using distributionVersion to Drive Upgrades
+
+## Status
+
+Proposed
+
+## Context
+
+Cluster API contracts generally expect upgrades driven by the Version field, which represents the kubernetes version. However, OpenShift versions cannot be mapped directly to kubernetes versions. Furthermore, CAPI expects each Machine group (controlplane, each MD) to have their independent version. OpenShift does not support in-place upgrades under this model. Instead, the upgrade process must be centrally managed and coordinated through a specific field indicating the desired target version.
+
+The proposed `distributionVersion` field (see: [CAPI PR #11029](https://github.com/kubernetes-sigs/cluster-api/pull/11029)) has been introduced to address the lack of direct mapping between kubernetesVersion and OpenShift versions.
+
+However, we cannot drive upgrades by different sets of Machines (ControlPlane, MachineDeployments, etc.). OpenShift upgrades are centralized and managed exclusively through the Cluster Version Operator, meaning a unified approach is required. Therefore, it is necessary to treat the `distributionVersion` as representative of the entire cluster's version, not just a specific Machine group.
+
+Currently, we are setting the `distributionVersion` field on the ControlPlane resource. However, we semantically mean the "cluster version", not just the ControlPlane’s `distributionVersion`. Ideally, this field should be placed on the Cluster object, which would provide a more accurate representation of the entire cluster’s desired state.
+
+This is effectively an in-place upgrade
+
+If discussions with the upstream community are successful, we hope to see CORE CAPI adopt changes to accommodate our upgrade flow. This would allow us to move the `distributionVersion` field to the Cluster object (or a similar place) to better comply with CAPI contracts.
+
+## Decision
+
+- Continue to use `distributionVersion` to track OpenShift versions and drive upgrades.
+- Centralize upgrade handling by associating the `distributionVersion` field with the ControlPlane resource until upstream consensus is reached.
+- Treat upgrade as in-place
+- Pursue upstream discussions to enable placing `distributionVersion` on the Cluster object for better compatibility and adherence to CAPI contracts.
+
+## Consequences
+
+- Diverges from the standard CAPI upgrade contract.
+- Current approach forces `distributionVersion` changes on the ControlPlane resource to represent the whole cluster’s version, which is not ideal.
+- Risk of inconsistency if upstream changes are not accepted or if future changes conflict with our approach.
+- No version status available for Machines not controlled by the Openshift Assisted ControlPlane controller


### PR DESCRIPTION
Document architectural decisions that move away from CAPI contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section titled "ADRs" in the `README.md` file, providing structured references to architectural decision records related to distribution versions and upgrades.
  - Introduced two new documents detailing decisions on handling discrepancies between CAPI contracts and OpenShift's versioning, as well as managing upgrades in OpenShift environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->