### PR TITLE
MGMT-20067: remove arch suffix from Spec.DistributionVersion

### DIFF
--- a/bootstrap/internal/controller/agent_controller_test.go
+++ b/bootstrap/internal/controller/agent_controller_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Agent Controller", func() {
 		When("an Agent resource with a valid Machine with OACs, and no agent ref", func() {
 			It("should add the agent ref to OAC status", func() {
 				By("Creating the OpenshiftAssistedConfig")
-				oac := NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
+				oac := testutils.NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
 				Expect(k8sClient.Create(ctx, oac)).To(Succeed())
 
 				agent := testutils.NewAgentWithInfraEnvLabel(namespace, agentName, machineName)
@@ -188,7 +188,7 @@ var _ = Describe("Agent Controller", func() {
 				Expect(k8sClient.Create(ctx, agent)).To(Succeed())
 
 				By("Creating the OpenshiftAssistedConfig")
-				oac := NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
+				oac := testutils.NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
 				oac.Status.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
 				Expect(k8sClient.Create(ctx, oac)).To(Succeed())
 
@@ -217,7 +217,7 @@ var _ = Describe("Agent Controller", func() {
 		When("an Agent resource with matching InfraEnv, and machine (worker)", func() {
 			It("should reconcile with a valid accepted worker agent", func() {
 				By("Creating the OpenshiftAssistedConfig")
-				oac := NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
+				oac := testutils.NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
 				Expect(k8sClient.Create(ctx, oac)).To(Succeed())
 
 				machine := testutils.NewMachine(namespace, machineName, clusterName)
@@ -250,7 +250,7 @@ var _ = Describe("Agent Controller", func() {
 		When("an Agent resource with matching InfraEnv, and machine (master)", func() {
 			It("should reconcile with a valid accepted master agent", func() {
 				By("Creating the OpenshiftAssistedConfig")
-				oac := NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
+				oac := testutils.NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
 				Expect(k8sClient.Create(ctx, oac)).To(Succeed())
 
 				machine := testutils.NewMachine(namespace, machineName, clusterName)

--- a/bootstrap/internal/controller/infraenv_controller_test.go
+++ b/bootstrap/internal/controller/infraenv_controller_test.go
@@ -129,7 +129,7 @@ var _ = Describe("InfraEnv Controller", func() {
 				}
 				infraEnv.Status.ISODownloadURL = DownloadURL
 				Expect(k8sClient.Create(ctx, infraEnv)).To(Succeed())
-				oac := NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
+				oac := testutils.NewOpenshiftAssistedConfig(namespace, oacName, clusterName)
 				Expect(k8sClient.Create(ctx, oac)).To(Succeed())
 
 				By("reconciling the InfraEnv")
@@ -155,7 +155,7 @@ var _ = Describe("InfraEnv Controller", func() {
 				infraEnv.Status.ISODownloadURL = DownloadURL
 				Expect(k8sClient.Create(ctx, infraEnv)).To(Succeed())
 
-				oac := NewOpenshiftAssistedConfigWithInfraEnv(namespace, oacName, clusterName, infraEnv)
+				oac := testutils.NewOpenshiftAssistedConfigWithInfraEnv(namespace, oacName, clusterName, infraEnv)
 				Expect(k8sClient.Create(ctx, oac)).To(Succeed())
 
 				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -231,7 +231,7 @@ var _ = Describe("InfraEnv Controller", func() {
 			}
 			infraEnv.Status.ISODownloadURL = DownloadURL
 			Expect(k8sClient.Create(ctx, infraEnv)).To(Succeed())
-			oac = NewOpenshiftAssistedConfigWithInfraEnv(namespace, oacName, clusterName, infraEnv)
+			oac = testutils.NewOpenshiftAssistedConfigWithInfraEnv(namespace, oacName, clusterName, infraEnv)
 			Expect(k8sClient.Create(ctx, oac)).To(Succeed())
 		})
 

--- a/bootstrap/main_test.go
+++ b/bootstrap/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -103,6 +103,11 @@ func (r *ClusterDeploymentReconciler) ensureAgentClusterInstall(
 		log.Error(err, "failed to retrieve owner Cluster from the API Server")
 		return ctrl.Result{}, err
 	}
+
+	arch, err := getArchitectureFromBootstrapConfigs(ctx, r.Client, &oacp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	imageSet := computeClusterImageSet(clusterDeployment.Name, getReleaseImage(oacp))
 	err = util.CreateOrUpdate(ctx, r.Client, imageSet)
 	if err != nil {
@@ -129,12 +134,12 @@ func (r *ClusterDeploymentReconciler) ensureAgentClusterInstall(
 // quay.io/openshift-release-dev/ocp-release:4.17.0-rc.2-x86_64
 // quay.io/okd/scos-release:4.18.0-okd-scos.ec.1
 // Can be overridden with annotation: cluster.x-k8s.io/release-image-repository-override=quay.io/myorg/myrepo
-func getReleaseImage(oacp controlplanev1alpha2.OpenshiftAssistedControlPlane) string {
+func getReleaseImage(oacp controlplanev1alpha2.OpenshiftAssistedControlPlane, architecture string) string {
 	releaseImageRepository, ok := oacp.Annotations[release.ReleaseImageRepositoryOverrideAnnotation]
 	if !ok {
 		releaseImageRepository = ""
 	}
-	return release.GetReleaseImage(oacp.Spec.DistributionVersion, releaseImageRepository)
+	return release.GetReleaseImage(oacp.Spec.DistributionVersion, releaseImageRepository, architecture)
 }
 
 func (r *ClusterDeploymentReconciler) getWorkerNodesCount(ctx context.Context, cluster *clusterv1.Cluster) int {

--- a/controlplane/internal/release/release.go
+++ b/controlplane/internal/release/release.go
@@ -50,14 +50,14 @@ func IsGA(version string) bool {
 }
 
 // Get release image based on desired version and potentiall override (can be empty)
-func GetReleaseImage(desiredVersion, repositoryOverride string) string {
+func GetReleaseImage(desiredVersion, repositoryOverride string, architecture string) string {
 	if repositoryOverride != "" {
-		return fmt.Sprintf("%s:%s", repositoryOverride, desiredVersion)
+		return fmt.Sprintf("%s:%s-%s", repositoryOverride, desiredVersion, architecture)
 
 	}
 	repository := OCPRepository
 	if IsOKD(desiredVersion) {
 		repository = OKDRepository
 	}
-	return fmt.Sprintf("%s:%s", repository, desiredVersion)
+	return fmt.Sprintf("%s:%s-%s", repository, desiredVersion, architecture)
 }

--- a/controlplane/internal/upgrade/mock_upgrade.go
+++ b/controlplane/internal/upgrade/mock_upgrade.go
@@ -118,9 +118,9 @@ func (mr *MockClusterUpgradeMockRecorder) IsUpgradeInProgress(ctx interface{}) *
 }
 
 // UpdateClusterVersionDesiredUpdate mocks base method.
-func (m *MockClusterUpgrade) UpdateClusterVersionDesiredUpdate(ctx context.Context, desiredVersion string, options ...ClusterUpgradeOption) error {
+func (m *MockClusterUpgrade) UpdateClusterVersionDesiredUpdate(ctx context.Context, desiredVersion, architecture string, options ...ClusterUpgradeOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, desiredVersion}
+	varargs := []interface{}{ctx, desiredVersion, architecture}
 	for _, a := range options {
 		varargs = append(varargs, a)
 	}
@@ -130,8 +130,8 @@ func (m *MockClusterUpgrade) UpdateClusterVersionDesiredUpdate(ctx context.Conte
 }
 
 // UpdateClusterVersionDesiredUpdate indicates an expected call of UpdateClusterVersionDesiredUpdate.
-func (mr *MockClusterUpgradeMockRecorder) UpdateClusterVersionDesiredUpdate(ctx, desiredVersion interface{}, options ...interface{}) *gomock.Call {
+func (mr *MockClusterUpgradeMockRecorder) UpdateClusterVersionDesiredUpdate(ctx, desiredVersion, architecture interface{}, options ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, desiredVersion}, options...)
+	varargs := append([]interface{}{ctx, desiredVersion, architecture}, options...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterVersionDesiredUpdate", reflect.TypeOf((*MockClusterUpgrade)(nil).UpdateClusterVersionDesiredUpdate), varargs...)
 }

--- a/controlplane/internal/upgrade/upgrade.go
+++ b/controlplane/internal/upgrade/upgrade.go
@@ -35,7 +35,7 @@ type ClusterUpgrade interface {
 	IsUpgradeInProgress(ctx context.Context) (bool, error)
 	GetCurrentVersion(ctx context.Context) (string, error)
 	IsDesiredVersionUpdated(ctx context.Context, desiredVersion string) (bool, error)
-	UpdateClusterVersionDesiredUpdate(ctx context.Context, desiredVersion string, options ...ClusterUpgradeOption) error
+	UpdateClusterVersionDesiredUpdate(ctx context.Context, desiredVersion string, architecture string, options ...ClusterUpgradeOption) error
 }
 
 func NewOpenshiftUpgradeFactory(remoteImage containers.RemoteImage, clientGenerator workloadclient.ClientGenerator) *OpenshiftUpgradeFactory {
@@ -124,7 +124,7 @@ func (u *OpenshiftUpgrader) IsDesiredVersionUpdated(ctx context.Context, desired
 }
 
 // Updates the cluster's desired version
-func (u *OpenshiftUpgrader) UpdateClusterVersionDesiredUpdate(ctx context.Context, desiredVersion string, options ...ClusterUpgradeOption) error {
+func (u *OpenshiftUpgrader) UpdateClusterVersionDesiredUpdate(ctx context.Context, desiredVersion string, architecture string, options ...ClusterUpgradeOption) error {
 	repositoryOverride := getOption(ReleaseImageRepositoryOverrideOption, options...)
 	clusterVersion, err := u.getClusterVersion(ctx)
 	if err != nil {
@@ -140,7 +140,7 @@ func (u *OpenshiftUpgrader) UpdateClusterVersionDesiredUpdate(ctx context.Contex
 		return nil
 	}
 	pullSecret := getOption(ReleaseImagePullSecretOption, options...)
-	releaseImageWithDigest, err := u.getReleaseImageWithDigest(release.GetReleaseImage(desiredVersion, repositoryOverride), []byte(pullSecret))
+	releaseImageWithDigest, err := u.getReleaseImageWithDigest(release.GetReleaseImage(desiredVersion, repositoryOverride, architecture), []byte(pullSecret))
 	if err != nil {
 		return err
 	}

--- a/controlplane/internal/upgrade/upgrade_test.go
+++ b/controlplane/internal/upgrade/upgrade_test.go
@@ -145,6 +145,7 @@ var _ = Describe("OpenShift Upgrader", func() {
 		Context("UpdateClusterVersionDesiredUpdate", func() {
 			It("should update GA version without image", func() {
 				err := upgrader.UpdateClusterVersionDesiredUpdate(ctx, "4.11.0",
+					"x86_64",
 					upgrade.ClusterUpgradeOption{
 						Name:  upgrade.ReleaseImageRepositoryOverrideOption,
 						Value: "quay.io/openshift-release-dev/ocp-release",
@@ -158,9 +159,10 @@ var _ = Describe("OpenShift Upgrader", func() {
 			})
 
 			It("should update non-GA version with image", func() {
-				mockRemoteImage.EXPECT().GetDigest(gomock.Any(), gomock.Any()).Return("sha256:123456", nil)
+				mockRemoteImage.EXPECT().GetDigest("quay.io/openshift-release-dev/ocp-release:4.11.0-rc.1-x86_64", gomock.Any()).Return("sha256:123456", nil)
 
 				err := upgrader.UpdateClusterVersionDesiredUpdate(ctx, "4.11.0-rc.1",
+					"x86_64",
 					upgrade.ClusterUpgradeOption{
 						Name:  upgrade.ReleaseImagePullSecretOption,
 						Value: pullsecret,

--- a/examples/multinode-example.yaml
+++ b/examples/multinode-example.yaml
@@ -57,7 +57,7 @@ spec:
     nodeRegistration:
       kubeletExtraLabels:
       - 'metal3.io/uuid="${METADATA_UUID}"'
-  distributionVersion: 4.19.0-ec.2-x86_64
+  distributionVersion: 4.19.0-ec.2
   config:
     apiVIPs:
     - 192.168.222.40

--- a/examples/sno-example.yaml
+++ b/examples/sno-example.yaml
@@ -57,7 +57,7 @@ spec:
     nodeRegistration:
       kubeletExtraLabels:
         - 'metal3.io/uuid="${METADATA_UUID}"'
-  distributionVersion: 4.19.0-ec.2-x86_64
+  distributionVersion: 4.19.0-ec.2
   config:
     baseDomain: lab.home
     pullSecretRef:

--- a/test/ansible/run_test.yaml
+++ b/test/ansible/run_test.yaml
@@ -20,7 +20,7 @@
     ssh_authorized_key: "{{ lookup('ansible.builtin.env', 'SSH_AUTHORIZED_KEY') }}"
     pullsecret: "{{ lookup('ansible.builtin.env', 'PULLSECRET') }}"
     container_tag: "{{ lookup('ansible.builtin.env', 'CONTAINER_TAG', default='local')}}"
-    upgrade_to_version: "4.19.0-ec.3-x86_64"
+    upgrade_to_version: "4.19.0-ec.3"
     cluster_name: "test-{{cluster_topology}}"
   tasks:
   - name: Distribution

--- a/test/utils/unit.go
+++ b/test/utils/unit.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	metal3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	v1alpha2 "github.com/openshift-assisted/cluster-api-agent/bootstrap/api/v1alpha1"
 	controlplanev1alpha1 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/api/v1beta1"
@@ -236,4 +237,34 @@ func NewBareMetalHost(namespace, name string) *v1alpha1.BareMetalHost {
 			Namespace: namespace,
 		},
 	}
+}
+
+func NewOpenshiftAssistedConfigWithInfraEnv(
+	namespace, name, clusterName string,
+	infraEnv *v1beta1.InfraEnv,
+) *v1alpha2.OpenshiftAssistedConfig {
+	var ref *corev1.ObjectReference
+	if infraEnv != nil {
+		ref = &corev1.ObjectReference{
+			Namespace: infraEnv.GetNamespace(),
+			Name:      infraEnv.GetName(),
+		}
+	}
+	return &v1alpha2.OpenshiftAssistedConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         clusterName,
+				clusterv1.MachineControlPlaneLabel: "control-plane",
+			},
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: v1alpha2.OpenshiftAssistedConfigStatus{
+			InfraEnvRef: ref,
+		},
+	}
+}
+
+func NewOpenshiftAssistedConfig(namespace, name, clusterName string) *v1alpha2.OpenshiftAssistedConfig {
+	return NewOpenshiftAssistedConfigWithInfraEnv(namespace, name, clusterName, nil)
 }


### PR DESCRIPTION
Architecture should be fetched from bootstrap config instead.
If we have the same arch for all nodes, we should use arch-specific image, multi otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced release image retrieval to support multi-architecture configurations during upgrades, ensuring that the appropriate release image is selected based on the target CPU architectures.
  - Introduced new utility functions for creating `OpenshiftAssistedConfig` objects with and without references to `InfraEnv`.

- **Refactor**
  - Streamlined version strings in configuration examples and playbooks by removing redundant architecture suffixes, resulting in more consistent and simplified version declarations.

- **Bug Fixes**
  - Improved test coverage for architecture-specific configurations in the ClusterDeployment Controller tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->