### PR TITLE
add action to build and push images

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+    branches:
+      - master
+
+jobs:
+  build:
+    env:
+      context: "./"
+      controlplane_image_name: "cluster-api-controlplane-provider-openshift-assisted"
+      bootstrap_image_name: "cluster-api-bootstrap-provider-openshift-assisted"
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          elif [[ $GITHUB_REF == refs/heads/master ]]; then
+            TAG=latest
+          else
+            BRANCH_NAME=${GITHUB_REF#refs/heads/}
+            TAG=${BRANCH_NAME//\//-}
+          fi
+          echo "IMAGE_TAG=${TAG#v}" >> $GITHUB_ENV
+          echo "Releasing ${TAG}"
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and publish bootstrap image to Quay
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: ${{ env.context }}
+          tags: "${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.bootstrap_image_name }}:${{env.IMAGE_TAG}}"
+          build-args: "PROVIDER=bootstrap"
+      - name: Build and publish controplane image to Quay
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: ${{ env.context }}
+          tags: "${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.controlplane_image_name }}:${{env.IMAGE_TAG}}"
+          build-args: "PROVIDER=controlplane"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,26 +28,6 @@ jobs:
         run: |
           sed -i "s,quay.io/edge-infrastructure/cluster-api-bootstrap-provider-openshift-assisted:latest,${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.bootstrap_image_name }}:${{env.VERSION}}," bootstrap-components.yaml
           sed -i "s,quay.io/edge-infrastructure/cluster-api-controlplane-provider-openshift-assisted:latest,${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.controlplane_image_name }}:${{env.VERSION}}," controlplane-components.yaml
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_SERVER }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Build and publish bootstrap image to Quay
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          context: ${{ env.context }}
-          tags: "${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.bootstrap_image_name }}:${{env.VERSION}}, ${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.bootstrap_image_name }}:latest"
-          build-args: "PROVIDER=bootstrap"
-      - name: Build and publish controplane image to Quay
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          context: ${{ env.context }}
-          tags: "${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.controlplane_image_name }}:${{env.VERSION}}, ${{ secrets.REGISTRY_SERVER }}/${{ secrets.REGISTRY_NAMESPACE }}/${{ env.controlplane_image_name }}:latest"
-          build-args: "PROVIDER=controlplane"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v0.1.14
         with:


### PR DESCRIPTION
Add an action to just push image on push on tag matching or selected branches.
For now we only push on master, once we'll introduce branches we can apply some rules to sanitize its naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated workflow for container image releases that dynamically assigns version tags for stable and development updates.

- **Chores**
  - Streamlined the overall release process by removing redundant image publishing steps, ensuring a more efficient and focused release operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->