### PR TITLE
remove limit for number of containers in containers.conf

### DIFF
--- a/test/playbooks/roles/network_setup/tasks/main.yaml
+++ b/test/playbooks/roles/network_setup/tasks/main.yaml
@@ -12,6 +12,17 @@
     regexp: '^#dns_servers = \[\]'
     line: 'dns_servers = ["192.168.222.1", "8.8.8.8"]'
     state: present
+- name: Unlimited number of pids for podman
+  ansible.builtin.lineinfile:
+    path: /usr/share/containers/containers.conf
+    regexp: '^# pids_limit = .*'
+    line: 'pids_limit = -1'
+    state: present
+- name: Restart podman service
+  ansible.builtin.systemd_service:
+    state: restarted
+    daemon_reload: true
+    name: podman
 # create libvirt network with dns server (only recursive)
 - name: Start libvirt network
   community.libvirt.virt_net:


### PR DESCRIPTION
This settings was never persisted in ansible, however we normally reach this number easily. The symptoms are pods crashing badly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced container management by enabling the system to support an unlimited number of process IDs, improving operational scalability and flexibility.
  - Added functionality to restart the podman service, ensuring smoother operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->