### PR TITLE
MGMT-19979: Propagate ClusterVersion upgrade status message

### DIFF
--- a/controlplane/api/v1alpha2/condition_consts.go
+++ b/controlplane/api/v1alpha2/condition_consts.go
@@ -36,6 +36,9 @@ const (
 	// UpgradeInProgressReason (Severity=Info) documents that an upgrade is in progress.
 	UpgradeInProgressReason = "UpgradeInProgress"
 
+	// UpgradeFailedReason (Severity=Error) documents that an upgrade has failed.
+	UpgradeFailedReason = "UpgradeFailed"
+
 	// UpgradeImageUnavailableReason (Severity=Error) documents whether an upgrade image is available
 	UpgradeImageUnavailableReason = "UpgradeImageUnavailable"
 

--- a/controlplane/internal/upgrade/mock_upgrade.go
+++ b/controlplane/internal/upgrade/mock_upgrade.go
@@ -87,6 +87,21 @@ func (mr *MockClusterUpgradeMockRecorder) GetCurrentVersion(ctx interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentVersion", reflect.TypeOf((*MockClusterUpgrade)(nil).GetCurrentVersion), ctx)
 }
 
+// GetUpgradeStatus mocks base method.
+func (m *MockClusterUpgrade) GetUpgradeStatus(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpgradeStatus", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUpgradeStatus indicates an expected call of GetUpgradeStatus.
+func (mr *MockClusterUpgradeMockRecorder) GetUpgradeStatus(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpgradeStatus", reflect.TypeOf((*MockClusterUpgrade)(nil).GetUpgradeStatus), ctx)
+}
+
 // IsDesiredVersionUpdated mocks base method.
 func (m *MockClusterUpgrade) IsDesiredVersionUpdated(ctx context.Context, desiredVersion string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/controlplane/internal/upgrade/upgrade_test.go
+++ b/controlplane/internal/upgrade/upgrade_test.go
@@ -176,6 +176,13 @@ var _ = Describe("OpenShift Upgrader", func() {
 				Expect(updatedCV.Spec.DesiredUpdate.Force).To(BeTrue())
 			})
 		})
+		Context("GetUpgradeStatus", func() {
+			It("should return an upgrade is in progress message", func() {
+				msg, err := upgrader.GetUpgradeStatus(ctx)
+				Expect(err).To(BeNil())
+				Expect(msg).To(Equal("upgrade is in progress"))
+			})
+		})
 	})
 })
 
@@ -188,6 +195,16 @@ func getClusterVersion(history []configv1.UpdateHistory) configv1.ClusterVersion
 			History: history,
 			Desired: configv1.Release{
 				Version: "4.10.0",
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Message: "upgrade is in progress",
+					Status:  configv1.ConditionTrue,
+				},
+				{
+					Message: "upgrade is not in progress",
+					Status:  configv1.ConditionFalse,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Adds the upgrade message from the ClusterVersion in the workload cluster to the OACP's upgrade status so it's transparent to the user. Also adds a failure reason in case the upgrade fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new constant for upgrade failure reasons, enhancing clarity on upgrade issues.
  - Improved upgrade status feedback with detailed messages for ongoing and failed upgrades.

- **Tests**
  - Expanded test coverage validates the improved upgrade status handling and message consistency under various upgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->