### PR TITLE
split dockerfiles

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Jinja2 CLI
+        run: pip install jinja2-cli
       - name: Determine image tag
         id: tag
         run: |

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Jinja2 CLI
+        run: pip install jinja2-cli
       - name: Build images from Dockerfile
         run: make docker-build-all
       - name: Create scans folder

--- a/Dockerfile.bootstrap-provider
+++ b/Dockerfile.bootstrap-provider
@@ -1,0 +1,37 @@
+# Build the manager binary
+FROM docker.io/library/golang:1.23 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY bootstrap/main.go bootstrap/main.go
+COPY bootstrap/api/ bootstrap/api/
+COPY controlplane/api/ controlplane/api/
+COPY util util
+COPY pkg pkg
+COPY assistedinstaller assistedinstaller
+COPY bootstrap/internal/ bootstrap/internal/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager bootstrap/main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/Dockerfile.controlplane-provider
+++ b/Dockerfile.controlplane-provider
@@ -2,7 +2,6 @@
 FROM docker.io/library/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
-ARG PROVIDER
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -13,20 +12,20 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY ${PROVIDER}/main.go ${PROVIDER}/main.go
+COPY controlplane/main.go controlplane/main.go
 COPY bootstrap/api/ bootstrap/api/
 COPY controlplane/api/ controlplane/api/
 COPY util util
 COPY pkg pkg
 COPY assistedinstaller assistedinstaller
-COPY ${PROVIDER}/internal/ ${PROVIDER}/internal/
+COPY controlplane/internal/ controlplane/internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=amd64 go build -a -o manager ${PROVIDER}/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager controlplane/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.distrobox
+++ b/Dockerfile.distrobox
@@ -1,0 +1,20 @@
+FROM golang:1.23-bookworm
+RUN curl -sSLO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" &&\
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl &&\
+    curl -sSLo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64 &&\
+    chmod +x ./kind &&\
+    mv ./kind /usr/local/bin/kind &&\
+    curl -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/clusterctl-linux-amd64 -o clusterctl &&\
+    install -o root -g root -m 0755 clusterctl /usr/local/bin/clusterctl &&\
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 &&\
+    chmod 700 get_helm.sh &&\
+    ./get_helm.sh &&\
+    curl -sSL -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)" &&\
+    chmod +x kubebuilder && mv kubebuilder /usr/local/bin/ &&\
+    apt-get update && apt-get install -y python3-venv python3-pip &&\
+    python3 -m venv /opt/venv
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install jinja2-cli

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -1,0 +1,37 @@
+# Build the manager binary
+FROM docker.io/library/golang:1.23 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY {{ provider }}/main.go {{ provider }}/main.go
+COPY bootstrap/api/ bootstrap/api/
+COPY controlplane/api/ controlplane/api/
+COPY util util
+COPY pkg pkg
+COPY assistedinstaller assistedinstaller
+COPY {{ provider }}/internal/ {{ provider }}/internal/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager {{ provider }}/main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ After this we will be able to initialize clusterctl:
 clusterctl init --bootstrap openshift-agent --control-plane openshift-agent -i  metal3:v1.7.0
 ```
 
+## Using the Makefile
+
+The Makefile can be used through a distrobox environment to ensure all dependencies are met.
+
+```sh
+podman build -f Dockerfile.distrobox -t capoa-build .
+distrobox create --image capoa-build:latest capoa-build
+distrobox enter capoa-build
+
+make <target>
+```
+
+An exception to this is the `docker-build` target, which should be executed from a system where docker/podman is available (not within distrobox).
+
+### Building Docker Images
+
+The project uses a templated approach to generate Dockerfiles for both bootstrap and controlplane providers from a single `Dockerfile.j2` template.
+
+1. Generate the Dockerfiles:
+```sh
+make generate-dockerfiles
+```
+This will create:
+* Dockerfile.bootstrap-provider for the bootstrap provider
+* Dockerfile.controlplane-provider for the controlplane provider
+
+2. Build the Docker images:
+```sh
+make docker-build-all
+```
+
 ## Per host data
 
 Host data will be injected in the host through environment variables.


### PR DESCRIPTION
Split dockerfile into dedicated files one for each provider

/cc @carbonin 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Dockerfile template and automated generation of provider-specific Dockerfiles for building minimal, secure images.
  - Added a new distrobox-based Docker image with essential Kubernetes CLI tools and Python environment setup.
- **Chores**
  - Updated build process to use generated Dockerfiles and added Makefile targets for Dockerfile generation.
- **Documentation**
  - Added instructions for generating Dockerfiles and building Docker images to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->