### PR TITLE
fix okd version parsing

### DIFF
--- a/controlplane/internal/release/release.go
+++ b/controlplane/internal/release/release.go
@@ -55,9 +55,8 @@ func GetReleaseImage(desiredVersion, repositoryOverride string, architecture str
 		return fmt.Sprintf("%s:%s-%s", repositoryOverride, desiredVersion, architecture)
 
 	}
-	repository := OCPRepository
 	if IsOKD(desiredVersion) {
-		repository = OKDRepository
+		return fmt.Sprintf("%s:%s", OKDRepository, desiredVersion)
 	}
-	return fmt.Sprintf("%s:%s-%s", repository, desiredVersion, architecture)
+	return fmt.Sprintf("%s:%s-%s", OCPRepository, desiredVersion, architecture)
 }


### PR DESCRIPTION
OKD release image does not have arch extension, as it is multi arch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the logic for determining and formatting release image strings, resulting in more consistent and predictable image references. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->