### PR TITLE
Update dockerfiles to use approved images

### DIFF
--- a/Dockerfile.bootstrap-provider
+++ b/Dockerfile.bootstrap-provider
@@ -1,9 +1,13 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.23 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+ENV USER_UID=1001 \
+    USER_NAME=openshift-assisted
+COPY --chown=${USER_UID} . /workspace
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -27,9 +31,7 @@ COPY bootstrap/internal/ bootstrap/internal/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager bootstrap/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile.controlplane-provider
+++ b/Dockerfile.controlplane-provider
@@ -1,9 +1,13 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.23 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+ENV USER_UID=1001 \
+    USER_NAME=openshift-assisted
+COPY --chown=${USER_UID} . /workspace
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -27,9 +31,7 @@ COPY controlplane/internal/ controlplane/internal/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager controlplane/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -1,9 +1,13 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.23 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+ENV USER_UID=1001 \
+    USER_NAME=openshift-assisted
+COPY --chown=${USER_UID} . /workspace
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -27,9 +31,7 @@ COPY {{ provider }}/internal/ {{ provider }}/internal/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager {{ provider }}/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
This also required a small workaround with the UID and working directory to ensure the build has write access to the WORKDIR (which it didn't without this change)

Without this the build was failing with:

```
command-line-arguments: go build command-line-arguments: copying /tmp/go-build1201661130/b001/exe/a.out: open manager: permission denied
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated container images to use Red Hat Universal Base Images (UBI) and minimal RHEL images for improved compatibility and security.
  - Adjusted user and ownership settings within containers for enhanced consistency and compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->