### PR TITLE
improve e2e tests: add okd example file, update dependencies

### DIFF
--- a/examples/multinode-okd-example.yaml.j2
+++ b/examples/multinode-okd-example.yaml.j2
@@ -1,0 +1,174 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: "{{ pullsecret }}"
+kind: Secret
+metadata:
+  name: pull-secret
+  namespace: test-capi
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: test-multinode-okd
+  namespace: test-capi
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 172.18.0.0/20
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha2
+    kind: OpenshiftAssistedControlPlane
+    name: test-multinode-okd
+    namespace: test-capi
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: Metal3Cluster
+    name: test-multinode-okd
+    namespace: test-capi
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3Cluster
+metadata:
+  name: test-multinode-okd
+  namespace: test-capi
+spec:
+  controlPlaneEndpoint:
+    host: test-multinode-okd.lab.home
+    port: 6443
+  noCloudProvider: true
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha2
+kind: OpenshiftAssistedControlPlane
+metadata:
+  name: test-multinode-okd
+  namespace: test-capi
+  annotations: {}
+spec:
+  openshiftAssistedConfigSpec:
+    pullSecretRef:
+      name: "pull-secret"
+    sshAuthorizedKey: "{{ ssh_authorized_key }}"
+    nodeRegistration:
+      kubeletExtraLabels:
+      - 'metal3.io/uuid="${METADATA_UUID}"'
+  distributionVersion: 4.19.0-okd-scos.ec.6
+  config:
+    apiVIPs:
+    - 192.168.222.40
+    ingressVIPs:
+    - 192.168.222.41
+    baseDomain: lab.home
+    pullSecretRef:
+      name: "pull-secret"
+    sshAuthorizedKey: "{{ ssh_authorized_key }}"
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: Metal3MachineTemplate
+      name: test-multinode-okd-controlplane
+      namespace: test-capi
+  replicas: 3
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3MachineTemplate
+metadata:
+  name: test-multinode-okd-controlplane
+  namespace: test-capi
+spec:
+  nodeReuse: false
+  template:
+    spec:
+      automatedCleaningMode: disabled
+      dataTemplate:
+        name: test-multinode-okd-controlplane-template
+      image:
+        checksum: https://cloud.centos.org/centos/scos/9/prod/streams/latest/x86_64/sha256sum.txt
+        checksumType: sha256
+        url: https://cloud.centos.org/centos/scos/9/prod/streams/latest/x86_64/scos-9.0.20250411-0-nutanix.x86_64.qcow2
+        format: qcow2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3MachineTemplate
+metadata:
+  name: test-multinode-okd-workers-2
+  namespace: test-capi
+spec:
+  nodeReuse: false
+  template:
+    spec:
+      automatedCleaningMode: metadata
+      dataTemplate:
+        name: test-multinode-okd-workers-template
+      image:
+        checksum: https://cloud.centos.org/centos/scos/9/prod/streams/latest/x86_64/sha256sum.txt
+        checksumType: sha256
+        url: https://cloud.centos.org/centos/scos/9/prod/streams/latest/x86_64/scos-9.0.20250411-0-nutanix.x86_64.qcow2
+        format: qcow2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: test-multinode-okd-controlplane-template
+  namespace: test-capi
+spec:
+  clusterName: test-multinode-okd
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: test-multinode-okd-workers-template
+  namespace: test-capi
+spec:
+  clusterName: test-multinode-okd
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: test-multinode-okd-worker
+  namespace: test-capi
+  labels:
+    cluster.x-k8s.io/cluster-name: test-multinode-okd
+spec:
+  clusterName: test-multinode-okd
+  replicas: 2
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: test-multinode-okd
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test-multinode-okd
+    spec:
+      clusterName: test-multinode-okd
+      bootstrap:
+        configRef:
+          name: test-multinode-okd-worker
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+          kind: OpenshiftAssistedConfigTemplate
+      infrastructureRef:
+        name: test-multinode-okd-workers-2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: Metal3MachineTemplate
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+kind: OpenshiftAssistedConfigTemplate
+metadata:
+  name: test-multinode-okd-worker
+  namespace: test-capi
+  labels:
+    cluster.x-k8s.io/cluster-name: test-multinode-okd
+spec:
+  template:
+    spec:
+      nodeRegistration:
+        # name: '${METADATA_NAME}'
+        kubeletExtraLabels:
+          - 'metal3.io/uuid="${METADATA_UUID}"'
+      pullSecretRef:
+        name: "pull-secret"
+      sshAuthorizedKey: "{{ ssh_authorized_key }}"

--- a/examples/sno-okd-example.yaml.j2
+++ b/examples/sno-okd-example.yaml.j2
@@ -10,7 +10,7 @@ type: kubernetes.io/dockerconfigjson
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: test-sno
+  name: test-sno-okd
   namespace: test-capi
 spec:
   clusterNetwork:
@@ -23,29 +23,29 @@ spec:
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha2
     kind: OpenshiftAssistedControlPlane
-    name: test-sno
+    name: test-sno-okd
     namespace: test-capi
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
-    name: test-sno
+    name: test-sno-okd
     namespace: test-capi
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
-  name: test-sno
+  name: test-sno-okd
   namespace: test-capi
 spec:
   controlPlaneEndpoint:
-    host: test-sno.lab.home
+    host: test-sno-okd.lab.home
     port: 6443
   noCloudProvider: true
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha2
 kind: OpenshiftAssistedControlPlane
 metadata:
-  name: test-sno
+  name: test-sno-okd
   namespace: test-capi
   annotations: {}
     #cluster.x-k8s.io/release-image-repository-override: registry.ci.openshift.org/ocp/release
@@ -57,7 +57,7 @@ spec:
     nodeRegistration:
       kubeletExtraLabels:
         - 'metal3.io/uuid="${METADATA_UUID}"'
-  distributionVersion: 4.19.0-ec.4
+  distributionVersion: 4.19.0-okd-scos.ec.6
   config:
     baseDomain: lab.home
     pullSecretRef:
@@ -67,14 +67,14 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: Metal3MachineTemplate
-      name: test-sno-controlplane
+      name: test-sno-okd-controlplane
       namespace: test-capi
   replicas: 1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
-  name: test-sno-controlplane
+  name: test-sno-okd-controlplane
   namespace: test-capi
 spec:
   nodeReuse: false
@@ -82,17 +82,17 @@ spec:
     spec:
       automatedCleaningMode: disabled
       dataTemplate:
-        name: test-sno-controlplane-template
+        name: test-sno-okd-controlplane-template
       image:
-        checksum: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/dev-4.19/sha256sum.txt
+        checksum: https://cloud.centos.org/centos/scos/9/prod/streams/latest/x86_64/sha256sum.txt
         checksumType: sha256
+        url: https://cloud.centos.org/centos/scos/9/prod/streams/latest/x86_64/scos-9.0.20250411-0-nutanix.x86_64.qcow2
         format: qcow2
-        url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/dev-4.19/rhcos-dev-4.19-x86_64-nutanix.x86_64.qcow2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
-  name: test-sno-controlplane-template
+  name: test-sno-okd-controlplane-template
   namespace: test-capi
 spec:
-  clusterName: test-sno
+  clusterName: test-sno-okd

--- a/test/e2e/manifests/infrastructure-operator/kustomization.yaml.j2
+++ b/test/e2e/manifests/infrastructure-operator/kustomization.yaml.j2
@@ -1,15 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/openshift/assisted-service/0c92e1ae0ba4d8fe2f29b15e9824b88405aea480/hack/crds/hive/hive.openshift.io_clusterdeployments.yaml
-  - https://raw.githubusercontent.com/openshift/assisted-service/0c92e1ae0ba4d8fe2f29b15e9824b88405aea480/hack/crds/hive/hive.openshift.io_clusterimagesets.yaml
-  - https://raw.githubusercontent.com/openshift/assisted-service/0c92e1ae0ba4d8fe2f29b15e9824b88405aea480/hack/crds/mce/managedclusters.cluster.open-cluster-management.io.yaml
-  - https://github.com/openshift/assisted-service/config/default?ref=v2.38.1
+  - https://raw.githubusercontent.com/openshift/assisted-service/refs/tags/v2.40.0/hack/crds/hive/hive.openshift.io_clusterdeployments.yaml
+  - https://raw.githubusercontent.com/openshift/assisted-service/refs/tags/v2.40.0/hack/crds/hive/hive.openshift.io_clusterimagesets.yaml
+  - https://raw.githubusercontent.com/openshift/assisted-service/refs/tags/v2.40.0/hack/crds/mce/managedclusters.cluster.open-cluster-management.io.yaml
+  - https://github.com/openshift/assisted-service/config/default?ref=v2.40.0
 
 images:
   - name: quay.io/edge-infrastructure/assisted-service
-    newName: {{ assisted_service_image }}
-    digest: "{{ assisted_service_version }}"
+    newName: {{ infrastructure_operator_image }}
+    digest: "{{ infrastructure_operator_version }}"
 
 patches:
   - target:

--- a/test/playbooks/roles/components_install/tasks/main.yaml
+++ b/test/playbooks/roles/components_install/tasks/main.yaml
@@ -119,24 +119,68 @@
     dest: /tmp/loadbalancer_ip
     mode: '0644'
 
-- name: prepare infrastructure-operator on target
+- name: Prepare infrastructure-operator
   delegate_to: localhost
   ansible.builtin.template:
     src: "{{ playbook_dir }}/../../test/e2e/manifests/infrastructure-operator/kustomization.yaml.j2"
     dest: "{{ playbook_dir }}/../../test/e2e/manifests/infrastructure-operator/kustomization.yaml"
+    mode: '0644'
   vars:
-    assisted_service_image: "{{ lookup('ansible.builtin.env', 'ASSISTED_SERVICE_IMAGE', default=default_assisted_service_image) }}"
-    assisted_service_el8_image: "{{ lookup('ansible.builtin.env', 'ASSISTED_SERVICE_EL8_IMAGE', default=default_assisted_service_el8_image) }}"
-    assisted_image_service_image: "{{ lookup('ansible.builtin.env', 'ASSISTED_IMAGE_SERVICE_IMAGE', default=default_assisted_image_service_image) }}"
-    assisted_installer_agent_image: "{{ lookup('ansible.builtin.env', 'ASSISTED_INSTALLER_AGENT_IMAGE', default=default_assisted_installer_agent_image) }}"
-    assisted_installer_controller_image: "{{ lookup('ansible.builtin.env', 'ASSISTED_INSTALLER_CONTROLLER_IMAGE', default=default_assisted_installer_controller_image) }}"
-    assisted_installer_image: "{{ lookup('ansible.builtin.env', 'ASSISTED_INSTALLER_IMAGE', default=default_assisted_installer_image) }}"
-    assisted_service_version: "{{ lookup('ansible.builtin.env', 'ASSISTED_SERVICE_VERSION', default=default_assisted_service_version) }}"
-    assisted_service_el8_version: "{{ lookup('ansible.builtin.env', 'ASSISTED_SERVICE_EL8_VERSION', default=default_assisted_service_el8_version) }}"
-    assisted_image_service_version: "{{ lookup('ansible.builtin.env', 'ASSISTED_IMAGE_SERVICE_VERSION', default=default_assisted_image_service_version) }}"
-    assisted_installer_agent_version: "{{ lookup('ansible.builtin.env', 'ASSISTED_INSTALLER_AGENT_VERSION', default=default_assisted_installer_agent_version) }}"
-    assisted_installer_controller_version: "{{ lookup('ansible.builtin.env', 'ASSISTED_INSTALLER_CONTROLLER_VERSION', default=default_assisted_installer_controller_version) }}"
-    assisted_installer_version: "{{ lookup('ansible.builtin.env', 'ASSISTED_INSTALLER_VERSION', default=default_assisted_installer_version) }}"
+    infrastructure_operator_image: >-
+      {{ lookup('ansible.builtin.env',
+      'INFRASTRUCTURE_OPERATOR_IMAGE',
+      default=default_infrastructure_operator_image) }}
+    assisted_service_image: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_SERVICE_IMAGE', default=default_assisted_service_image) }}
+    assisted_service_el8_image: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_SERVICE_EL8_IMAGE',
+      default=default_assisted_service_el8_image) }}
+    assisted_image_service_image: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_IMAGE_SERVICE_IMAGE',
+      default=default_assisted_image_service_image) }}
+    assisted_installer_agent_image: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_INSTALLER_AGENT_IMAGE',
+      default=default_assisted_installer_agent_image) }}
+    assisted_installer_controller_image: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_INSTALLER_CONTROLLER_IMAGE',
+      default=default_assisted_installer_controller_image) }}
+    assisted_installer_image: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_INSTALLER_IMAGE',
+      default=default_assisted_installer_image) }}
+    infrastructure_operator_version: >-
+      {{ lookup('ansible.builtin.env',
+      'INFRASTRUCTURE_OPERATOR_VERSION',
+      default=default_infrastructure_operator_version) }}
+    assisted_service_version: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_SERVICE_VERSION',
+      default=default_assisted_service_version) }}
+    assisted_service_el8_version: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_SERVICE_EL8_VERSION',
+      default=default_assisted_service_el8_version) }}
+    assisted_image_service_version: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_IMAGE_SERVICE_VERSION',
+      default=default_assisted_image_service_version) }}
+    assisted_installer_agent_version: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_INSTALLER_AGENT_VERSION',
+      default=default_assisted_installer_agent_version) }}
+    assisted_installer_controller_version: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_INSTALLER_CONTROLLER_VERSION',
+      default=default_assisted_installer_controller_version) }}
+    assisted_installer_version: >-
+      {{ lookup('ansible.builtin.env',
+      'ASSISTED_INSTALLER_VERSION',
+      default=default_assisted_installer_version) }}
 
 - name: Deploy infrastructure operator
   kubernetes.core.k8s:

--- a/test/playbooks/run_test.yaml
+++ b/test/playbooks/run_test.yaml
@@ -9,17 +9,19 @@
     cluster_topology: "{{ lookup('ansible.builtin.env', 'CLUSTER_TOPOLOGY', default='multinode') }}"
     example_manifest: "{{ cluster_topology }}-example.yaml.j2"
     default_assisted_service_image: "quay.io/edge-infrastructure/assisted-service"
+    default_infrastructure_operator_image: "quay.io/edge-infrastructure/assisted-service"
     default_assisted_service_el8_image: "quay.io/edge-infrastructure/assisted-service-el8"
     default_assisted_image_service_image: "quay.io/edge-infrastructure/assisted-image-service"
     default_assisted_installer_agent_image: "quay.io/edge-infrastructure/assisted-installer-agent"
     default_assisted_installer_controller_image: "quay.io/edge-infrastructure/assisted-installer-controller"
     default_assisted_installer_image: "quay.io/edge-infrastructure/assisted-installer"
-    default_assisted_service_version: "sha256:a78af04976f68f4e33b3a53001c959c15b7c350cb2b8836004066a40fd1e261d"
-    default_assisted_service_el8_version: "sha256:a78af04976f68f4e33b3a53001c959c15b7c350cb2b8836004066a40fd1e261d"
-    default_assisted_image_service_version: "sha256:007f0b23d6e3f52837f44d3b4f02565e0121967e8b64e75dc38ba1b1d48e58c2"
-    default_assisted_installer_agent_version: "sha256:b9cf4a9246eb3eb2d71dc17f6034c875be9c7d63120fa5a683b975dd878e6b20"
-    default_assisted_installer_controller_version: "sha256:6fd6d481b66b78853214fbce28acbd45fd9345480c70b8775078ce44ba3d2ab8"
-    default_assisted_installer_version: "sha256:7c4e456c16d9f1171a8328485e89d63622a5d1bc24c6e553031119b8027f3384"
+    default_assisted_service_el8_version: "sha256:fc5c31be9a528a10485a5d2c7ca82d17cf2a560948e3efa5c0042a5565dc1acf"
+    default_assisted_image_service_version: "sha256:c9c0623baa3d364131720914d68fa6267d8a242af1de3a7c4a46bb1d18a1fac4"
+    default_assisted_installer_agent_version: "sha256:fc1abc80463b74917c09c3f3393b97ea1175c6207de616def2a8a25419049cae"
+    default_assisted_installer_controller_version: "sha256:c707d06e0d232a0a067b30ede5321d3212609dd1281798952866bc4712b4578a"
+    default_infrastructure_operator_version: "sha256:a78af04976f68f4e33b3a53001c959c15b7c350cb2b8836004066a40fd1e261d"
+    default_assisted_installer_version: "sha256:5cf1b47fc8bc129fa5cf109c8b9759b3fdc033643ee4f2f1d8bcdf0de8ddfaca"
+    default_assisted_service_version: "sha256:ef7c53fe1dee4c0a6616c53d7d84c3c9b4051d00048b38d421dcf1ceb6c58aea"
     capi_version: "{{ lookup('ansible.builtin.env', 'CAPI_VERSION', default='v1.9.6') }}"
     capm3_version: "{{ lookup('ansible.builtin.env', 'CAPM3_VERSION', default='v1.9.3') }}"
     dist_dir: "{{ lookup('ansible.builtin.env', 'DIST_DIR') }}"
@@ -29,7 +31,6 @@
     pullsecret: "{{ lookup('ansible.builtin.env', 'PULLSECRET') }}"
     container_tag: "{{ lookup('ansible.builtin.env', 'CONTAINER_TAG', default='local')}}"
     cluster_name: "test-{{cluster_topology}}"
-    upgrade_to_version: "4.19.0-ec.3"
     medium_delay: 10
     medium_retries: 60
     high_delay: 60
@@ -51,4 +52,5 @@
     - bmh_setup
     - cluster_install
     - assert_install
-    - assert_upgrade
+    - role: assert_upgrade
+      when: "upgrade_to_version is defined"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manifest templates for deploying multi-node and single-node OpenShift OKD clusters using Metal3 and Assisted Installer integration.
- **Updates**
  - Updated OpenShift Assisted Control Plane version in single-node manifest to 4.19.0-ec.4.
  - Updated test infrastructure manifests to reference newer assisted-service releases and improved image variable handling.
- **Chores**
  - Enhanced Ansible tasks and playbooks with new variables, updated image digests, and improved conditional role execution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->