### PR TITLE
Add renovate.json to prevent dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+    "schedule": ["on Saturday"],
+    "groupName": "Konflux build pipeline",
+    "includePaths": [".tekton/*"],
+    "commitMessagePrefix": "NO-ISSUE: ",
+    "labels": ["lgtm", "approved"]
+}


### PR DESCRIPTION
We don't want go module updates in the 2.9 branch.
These will be updated as needed to master and backported or fast-forwarded to this branch.