### PR TITLE
split namespace between bootstrap and controlplane providers

### DIFF
--- a/bootstrap-components.yaml
+++ b/bootstrap-components.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capoa-system
+  name: capoa-bootstrap-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -583,13 +583,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: capoa-bootstrap-leader-election-role
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 rules:
 - apiGroups:
   - ""
@@ -728,7 +728,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: capoa-bootstrap-leader-election-rolebinding
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -736,7 +736,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -749,13 +749,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 spec:
   replicas: 1
   selector:

--- a/bootstrap/config/manager/manager.yaml
+++ b/bootstrap/config/manager/manager.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capoa-system
+  name: capoa-bootstrap-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 spec:
   selector:
     matchLabels:

--- a/bootstrap/config/prometheus/monitor.yaml
+++ b/bootstrap/config/prometheus/monitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: capoa-bootstrap-controller-manager-metrics-monitor
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 spec:
   endpoints:
     - path: /metrics

--- a/bootstrap/config/rbac/leader_election_role.yaml
+++ b/bootstrap/config/rbac/leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: capoa-bootstrap-leader-election-role
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 rules:
 - apiGroups:
   - ""

--- a/bootstrap/config/rbac/leader_election_role_binding.yaml
+++ b/bootstrap/config/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: capoa-bootstrap-leader-election-rolebinding
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system

--- a/bootstrap/config/rbac/role_binding.yaml
+++ b/bootstrap/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system

--- a/bootstrap/config/rbac/service_account.yaml
+++ b/bootstrap/config/rbac/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system

--- a/controlplane-components.yaml
+++ b/controlplane-components.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capoa-system
+  name: capoa-controlplane-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -678,13 +678,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: capoa-controlplane-leader-election-role
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 rules:
 - apiGroups:
   - ""
@@ -874,7 +874,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: capoa-controlplane-leader-election-rolebinding
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -882,7 +882,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -895,13 +895,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 spec:
   replicas: 1
   selector:

--- a/controlplane/config/manager/manager.yaml
+++ b/controlplane/config/manager/manager.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capoa-system
+  name: capoa-controlplane-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 spec:
   selector:
     matchLabels:

--- a/controlplane/config/prometheus/monitor.yaml
+++ b/controlplane/config/prometheus/monitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: capoa-controlplane-controller-manager-metrics-monitor
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 spec:
   endpoints:
     - path: /metrics

--- a/controlplane/config/rbac/leader_election_role.yaml
+++ b/controlplane/config/rbac/leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: capoa-controlplane-leader-election-role
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 rules:
 - apiGroups:
   - ""

--- a/controlplane/config/rbac/leader_election_role_binding.yaml
+++ b/controlplane/config/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: capoa-controlplane-leader-election-rolebinding
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system

--- a/controlplane/config/rbac/role_binding.yaml
+++ b/controlplane/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system

--- a/controlplane/config/rbac/service_account.yaml
+++ b/controlplane/config/rbac/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system

--- a/test/e2e/manifests/capboa/bootstrap_install.yaml
+++ b/test/e2e/manifests/capboa/bootstrap_install.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capoa-system
+  name: capoa-bootstrap-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -583,13 +583,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: capoa-bootstrap-leader-election-role
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 rules:
 - apiGroups:
   - ""
@@ -728,7 +728,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: capoa-bootstrap-leader-election-rolebinding
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -736,7 +736,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -749,13 +749,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capoa-bootstrap-controller-manager
-  namespace: capoa-system
+  namespace: capoa-bootstrap-system
 spec:
   replicas: 1
   selector:

--- a/test/e2e/manifests/capcoa/controlplane_install.yaml
+++ b/test/e2e/manifests/capcoa/controlplane_install.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capoa-system
+  name: capoa-controlplane-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -678,13 +678,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: capoa-controlplane-leader-election-role
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 rules:
 - apiGroups:
   - ""
@@ -874,7 +874,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: capoa-controlplane-leader-election-rolebinding
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -882,7 +882,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -895,13 +895,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capoa-controlplane-controller-manager
-  namespace: capoa-system
+  namespace: capoa-controlplane-system
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
/cc @jianzzha @carbonin 

Kustomize will not accept two resources with the same GVK and name in the same kustomization.yaml. We could work around it by creating a sub-kustomization and remove one namespace there, but it's awkward. By restoring 2 namespaces it will be easier to handle with kustomize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Kubernetes manifests to use new namespace names: `capoa-bootstrap-system` and `capoa-controlplane-system` instead of `capoa-system`.
  - All related resources, including Namespace, ServiceAccount, Role, RoleBinding, ClusterRoleBinding, Deployment, and monitoring configurations, now reference the updated namespaces.
  - No changes were made to roles, permissions, or container specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->