### PR TITLE
Add labels to images to satisfy konflux

### DIFF
--- a/Dockerfile.bootstrap-provider
+++ b/Dockerfile.bootstrap-provider
@@ -28,6 +28,19 @@ COPY bootstrap/internal/ bootstrap/internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager bootstrap/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ENV SUMMARY="The OpenShift Assisted bootstrap provider for use when installing OpenShift using CAPI" \
+    DESCRIPTION="The OpenShift Assisted bootstrap provider implements the CAPI bootstrap provider contract and allows installing OpenShift by integrating with Assisted Installer"
+
+
+LABEL name="cluster-api-provider-openshift-assisted-bootstrap" \
+      summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      com.redhat.component="cluster-api-provider-openshift-assisted-bootstrap" \
+      io.k8s.display-name="OpenShift Assisted cluster API bootstrap provider" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.openshift.tags="install,cluster,provisioning"
+
 WORKDIR /
 COPY --from=builder /opt/app-root/src/manager .
 USER 65532:65532

--- a/Dockerfile.controlplane-provider
+++ b/Dockerfile.controlplane-provider
@@ -28,6 +28,19 @@ COPY controlplane/internal/ controlplane/internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager controlplane/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ENV SUMMARY="The OpenShift Assisted controlplane provider for use when installing OpenShift using CAPI" \
+    DESCRIPTION="The OpenShift Assisted controlplane provider implements the CAPI controlplane provider contract and allows installing OpenShift by integrating with Assisted Installer"
+
+
+LABEL name="cluster-api-provider-openshift-assisted-controlplane" \
+      summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      com.redhat.component="cluster-api-provider-openshift-assisted-controlplane" \
+      io.k8s.display-name="OpenShift Assisted cluster API controlplane provider" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.openshift.tags="install,cluster,provisioning"
+
 WORKDIR /
 COPY --from=builder /opt/app-root/src/manager .
 USER 65532:65532

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -28,6 +28,19 @@ COPY {{ provider }}/internal/ {{ provider }}/internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager {{ provider }}/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ENV SUMMARY="The OpenShift Assisted {{ provider }} provider for use when installing OpenShift using CAPI" \
+    DESCRIPTION="The OpenShift Assisted {{ provider }} provider implements the CAPI {{ provider }} provider contract and allows installing OpenShift by integrating with Assisted Installer"
+
+
+LABEL name="cluster-api-provider-openshift-assisted-{{ provider }}" \
+      summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      com.redhat.component="cluster-api-provider-openshift-assisted-{{ provider }}" \
+      io.k8s.display-name="OpenShift Assisted cluster API {{ provider }} provider" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.openshift.tags="install,cluster,provisioning"
+
 WORKDIR /
 COPY --from=builder /opt/app-root/src/manager .
 USER 65532:65532


### PR DESCRIPTION
Without this the konflux enterprise contract validations were failing with errors like:

```
✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-openshift-assisted-bootstrap-mce-29@sha256:9002c9a8559817bd67570f09aa094a7da88184a15638c64425816f33a2ddbd2f
  Reason: The "com.redhat.component" label should not be inherited from the parent image
  Term: com.redhat.component
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:com.redhat.component" to the `exclude` section of the
  policy configuration.
  Solution: Update the image build process to overwrite the inherited labels.
```