### PR TITLE
NO-ISSUE: versions management - set GITHUB_TOKEN environment variable to enable gh cli usage

### DIFF
--- a/hack/versions-management/github_auth.sh
+++ b/hack/versions-management/github_auth.sh
@@ -32,9 +32,9 @@ if [ -z "$INSTALLATION_TOKEN" ]; then
 fi
 
 export GITHUB_APP_PRIVATE_KEY=$(cat ${GITHUB_APP_PRIVATE_KEY_PATH})
+export GITHUB_TOKEN="$INSTALLATION_TOKEN"
 repo_url="https://x-access-token:${INSTALLATION_TOKEN}@github.com/openshift-assisted/cluster-api-provider-openshift-assisted.git"
 git remote add "${CI_REMOTE_NAME:-versions_management}" "$repo_url"
 git remote set-url "${CI_REMOTE_NAME:-versions_management}" "$repo_url"
 git config --global user.name "CAPI version automation"
 git config --global user.email "capi-openshift-assisted@redhat.com"
-


### PR DESCRIPTION
Set GITHUB_TOKEN environment variable to enable the `gh` cli tool to create pull requests as part of the versions management automation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment variable exports to include a GitHub token for improved integration with GitHub services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->