### PR TITLE
use cherry-pick instead of fast-forward, due to diverging configuration on branches

### DIFF
--- a/.github/workflows/cherry_pick.yaml
+++ b/.github/workflows/cherry_pick.yaml
@@ -1,5 +1,5 @@
 ---
-name: Fast Forward Branch
+name: Cherry-Pick from Master
 
 on:
   push:
@@ -22,8 +22,8 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
-      - name: Attempt fast-forward $TARGET_BRANCH to master
+      - name: Cherry-pick master commits into  ${{ env.TARGET_BRANCH }}
         run: |
           git checkout "${TARGET_BRANCH}"
-          git merge --ff-only origin/master
+          git cherry-pick $(git rev-list --reverse --no-merges ${TARGET_BRANCH}..origin/master)
           git push origin "${TARGET_BRANCH}"


### PR DESCRIPTION
Some config is bound to be different (see Konflux), therefore simply fast-forwarding won't work.
This patch checks all non-merge commits on master that are not present on TARGET_BRANCH and re-applies them.


/cc @carbonin 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to use a cherry-pick strategy for syncing changes from the master branch, instead of a fast-forward merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->