### PR TITLE
NO-ISSUE: versions management - moving github authentication logic to after the snapshot test to avoid token getting time out during the test

### DIFF
--- a/hack/versions-management/ansible_test_runner.sh
+++ b/hack/versions-management/ansible_test_runner.sh
@@ -4,14 +4,14 @@ set -o pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-source "$SCRIPT_DIR/github_auth.sh"
-
 ARGS=()
 if [ "${DRY_RUN:-false}" = "true" ]; then
   ARGS+=(--dry-run)
 fi
 
 python "$SCRIPT_DIR/ansible_test_runner.py" "${ARGS[@]}"
+
+source "$SCRIPT_DIR/github_auth.sh"
 
 if [ "${DRY_RUN:-false}" = true ]; then
     echo "Ansible test runner has finished successfully"


### PR DESCRIPTION
In the versions management automation, the github authentication generates a token that's valid for only 10 minutes (limited by github). However, since the test phase takes longer to complete, the token expires before it's used. To address this, moved the authentication logic to after the test phase, as the test itself doesn't require github access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Adjusted the timing of GitHub authentication within the test runner script to occur after the Python script execution. No user-facing functionality is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->