### PR TITLE
add identity to cherry-pick job

### DIFF
--- a/.github/workflows/cherry_pick.yaml
+++ b/.github/workflows/cherry_pick.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Cherry-pick master commits into  ${{ env.TARGET_BRANCH }}
         run: |
+          git config --global user.email "capi-openshift-assisted@redhat.com"
+          git config --global user.name "CAPOA GitHub Action"
           git checkout "${TARGET_BRANCH}"
           git cherry-pick $(git rev-list --reverse --no-merges ${TARGET_BRANCH}..origin/master)
           git push origin "${TARGET_BRANCH}"


### PR DESCRIPTION
identity is needed to cherry pick

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to ensure consistent author information for commits created during automated cherry-pick operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->