### PR TITLE
NO-ISSUE: versions management - tag reconciler now tags the CAPOA repo that has been used to test the snapshot

### DIFF
--- a/hack/versions-management/ansible_test_runner.py
+++ b/hack/versions-management/ansible_test_runner.py
@@ -10,6 +10,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 def main():
     parser = argparse.ArgumentParser(description="Ansible Test Runner Service")
     parser.add_argument("--dry-run", action="store_true", help="Run in dry-run mode without making any changes")
+    parser.add_argument("--pending-snapshot-id", help="Pending snapshot to test")
     args = parser.parse_args()
     
     logger = setup_logger("AnsibleTestRunner")
@@ -17,7 +18,7 @@ def main():
     try:
         rc_file = os.environ.get("RELEASE_CANDIDATES_FILE", f"{ROOT_DIR}/release-candidates.yaml")
         logger.info(f"Starting ansible test runner with RC file: {rc_file}")
-        service = AnsibleTestRunnerService(file_path=rc_file, dry_run=args.dry_run)
+        service = AnsibleTestRunnerService(file_path=rc_file, dry_run=args.dry_run, pending_snapshot_id=args.pending_snapshot_id)
         service.run()
         logger.info("Ansible test run completed successfully")
         return 0

--- a/hack/versions-management/core/models/snapshot_metadata.py
+++ b/hack/versions-management/core/models/snapshot_metadata.py
@@ -6,3 +6,4 @@ class SnapshotMetadata:
     id: str
     generated_at: datetime
     status: str #can be either failed, successful or pending
+    tested_with_ref: str | None = None

--- a/hack/versions-management/core/models/version.py
+++ b/hack/versions-management/core/models/version.py
@@ -5,3 +5,4 @@ from .artifact import Artifact
 class Version:
     name: str
     artifacts: list[Artifact]
+    tested_with_ref: str | None = None

--- a/hack/versions-management/core/services/tag_reconciliation_service.py
+++ b/hack/versions-management/core/services/tag_reconciliation_service.py
@@ -6,29 +6,40 @@ from core.repositories import VersionRepository
 from core.services.service import Service
 from core.utils.logging import setup_logger
 
+CAPOA_REPO = "openshift-assisted/cluster-api-provider-openshift-assisted"
+
 class TagReconciliationService(Service):
-    def __init__(self, versions_file_path: str, dry_run: bool):
+    def __init__(self, versions_file_path: str, dry_run: bool = False):
         self.github: GitHubClient = GitHubClient()
         self.versions_repo: VersionRepository = VersionRepository(versions_file_path)
         self.logger: logging.Logger = setup_logger("TagReconciliationService")
         self.dry_run: bool = dry_run
 
+    def ensure_tag_exists(self, ref: str, repo: str, tag: str):
+        if repo != CAPOA_REPO:
+            tag = f"capoa-{tag}"
+        if not self.tag_exists(repo, tag):
+            if not self.dry_run:
+                self.create_tag(repo, ref, tag)
+            else:
+                self.logger.info(f"Dry run mode. tag {tag} on {ref} in repo {repo} has not been created")
+
     @override
     def run(self) -> None:
         versions = self.versions_repo.find_all()
         for version in versions:
-            if not version.name:
-                self.logger.warning("Skipping version without name")
+            if not version.name or not version.tested_with_ref:
+                self.logger.warning("Skipping version without name or tested_with_ref")
                 continue
             for artifact in version.artifacts:
                 repo = artifact.name
                 if not re.match(r"^openshift/", repo):
                     continue
-                if not self.tag_exists(repo, version.name):
-                    if not self.dry_run:
-                        self.create_tag(repo, artifact.ref, version.name)
-                    else:
-                        self.logger.info(f"Dry run mode. tag {version.name} on {artifact.ref} in repo {repo} has not been created")
+                self.ensure_tag_exists(artifact.ref, repo, version.name)
+
+            # tag capoa repo
+            self.ensure_tag_exists(version.tested_with_ref, CAPOA_REPO, version.name)
+
 
     def tag_exists(self, repo: str, tag: str) -> bool:
         try:

--- a/hack/versions-management/core/services/version_discovery_service.py
+++ b/hack/versions-management/core/services/version_discovery_service.py
@@ -16,7 +16,7 @@ from core.utils.logging import setup_logger
 
 
 class VersionDiscoveryService(Service):
-    def __init__(self, rc_file_path: str, components_file_path: str, dry_run: bool):
+    def __init__(self, rc_file_path: str, components_file_path: str, dry_run: bool = False):
         self.github: GitHubClient = GitHubClient()
         self.registry: ImageRegistryClient = ImageRegistryClient()
         self.rc_repository: ReleaseCandidateRepository = ReleaseCandidateRepository(rc_file_path)

--- a/hack/versions-management/test/assets/versions.yaml
+++ b/hack/versions-management/test/assets/versions.yaml
@@ -1,5 +1,6 @@
 versions:
 - name: v0.0.1
+  tested_with_ref: ref
   artifacts:
     - repository: https://github.com/kubernetes-sigs/cluster-api
       ref: v1.9.5

--- a/hack/versions-management/test/services/test_tags_reconciliation_service.py
+++ b/hack/versions-management/test/services/test_tags_reconciliation_service.py
@@ -6,6 +6,7 @@ import pytest
 from core.models import Artifact, Version
 from core.services.tag_reconciliation_service import TagReconciliationService
 
+CAPOA_REPO = "openshift-assisted/cluster-api-provider-openshift-assisted"
 ASSETS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "assets")
 
 
@@ -16,12 +17,14 @@ def versions_file(tmp_path):
     shutil.copy(source_file, dest_file)
     return dest_file
 
+
 @pytest.fixture
 def mock_github():
     with patch("core.services.tag_reconciliation_service.GitHubClient") as mock:
         github_client = MagicMock()
         mock.return_value = github_client
         yield github_client
+
 
 @pytest.fixture
 def mock_version_repo():
@@ -30,19 +33,31 @@ def mock_version_repo():
         mock.return_value = version_repo
         yield version_repo
 
+
 @pytest.fixture
 def service(versions_file, mock_version_repo, mock_github):
-    with patch("core.services.tag_reconciliation_service.GitHubClient"), \
-         patch("core.services.tag_reconciliation_service.VersionRepository"):
-        svc = TagReconciliationService(versions_file, False)
+    with (
+        patch("core.services.tag_reconciliation_service.GitHubClient"),
+        patch("core.services.tag_reconciliation_service.VersionRepository"),
+    ):
+        svc = TagReconciliationService(versions_file, dry_run=False)
         svc.logger = MagicMock()
         svc.github = mock_github
         svc.versions_repo = mock_version_repo
         svc.github.get_repo.return_value = MagicMock()
         svc.versions_repo.find_all.return_value = [
-            Version(name="v1.0.0", artifacts=[
-                Artifact(repository="https://github.com/openshift/repo", ref="abc123", name="openshift/repo", versioning_selection_mechanism="commit")
-            ])
+            Version(
+                name="v1.0.0",
+                tested_with_ref="ref",
+                artifacts=[
+                    Artifact(
+                        repository="https://github.com/openshift/repo",
+                        ref="abc123",
+                        name="openshift/repo",
+                        versioning_selection_mechanism="commit",
+                    )
+                ],
+            )
         ]
         return svc
 
@@ -52,32 +67,74 @@ def versions():
     return [
         Version(
             name="v1.0.0",
+            tested_with_ref="ref",
             artifacts=[
-                Artifact(repository="https://github.com/openshift/repo1", ref="abc123", name="openshift/repo1", versioning_selection_mechanism="commit"),
-                Artifact(repository="https://github.com/openshift/repo2", ref="def456", name="openshift/repo2", versioning_selection_mechanism="commit"),
-                Artifact(repository="https://github.com/kubernetes-sigs/repo3", ref="ghi789", name="kubernetes-sigs/repo3", versioning_selection_mechanism="commit"),
-            ]
+                Artifact(
+                    repository="https://github.com/openshift/repo1",
+                    ref="abc123",
+                    name="openshift/repo1",
+                    versioning_selection_mechanism="commit",
+                ),
+                Artifact(
+                    repository="https://github.com/openshift/repo2",
+                    ref="def456",
+                    name="openshift/repo2",
+                    versioning_selection_mechanism="commit",
+                ),
+                Artifact(
+                    repository="https://github.com/kubernetes-sigs/repo3",
+                    ref="ghi789",
+                    name="kubernetes-sigs/repo3",
+                    versioning_selection_mechanism="commit",
+                ),
+            ],
         ),
         Version(
             name="v1.1.0",
+            tested_with_ref="ref",
             artifacts=[
-                Artifact(repository="https://github.com/openshift/repo1", ref="jkl012", name="openshift/repo1", versioning_selection_mechanism="commit"),
-                Artifact(repository="https://github.com/openshift/repo2", ref="mno345", name="openshift/repo2", versioning_selection_mechanism="commit"),
-            ]
+                Artifact(
+                    repository="https://github.com/openshift/repo1",
+                    ref="jkl012",
+                    name="openshift/repo1",
+                    versioning_selection_mechanism="commit",
+                ),
+                Artifact(
+                    repository="https://github.com/openshift/repo2",
+                    ref="mno345",
+                    name="openshift/repo2",
+                    versioning_selection_mechanism="commit",
+                ),
+            ],
         ),
         Version(
             name="",  # Empty version name to test skipping
             artifacts=[
-                Artifact(repository="https://github.com/openshift/repo4", ref="pqr678", name="openshift/repo", versioning_selection_mechanism="commit"),
-            ]
-        )
+                Artifact(
+                    repository="https://github.com/openshift/repo4",
+                    ref="pqr678",
+                    name="openshift/repo",
+                    versioning_selection_mechanism="commit",
+                ),
+            ],
+        ),
     ]
+
 
 def test_reconciler_creates_tag(service):
     service.tag_exists = MagicMock(return_value=False)
     service.create_tag = MagicMock()
     service.run()
-    service.create_tag.assert_called_once()
+    # Should be called for both the artifact and CAPOA_REPO for each version
+    assert service.create_tag.call_count == 2
+    calls = [call_args.args for call_args in service.create_tag.call_args_list]
+    expected = [
+        ("openshift/repo", "abc123", "capoa-v1.0.0"),
+        (CAPOA_REPO, "ref", "v1.0.0"),
+    ]
+    for exp in expected:
+        assert exp in calls
+
 
 def test_reconciler_skips_existing_tag(service):
     service.tag_exists = MagicMock(return_value=True)
@@ -85,249 +142,239 @@ def test_reconciler_skips_existing_tag(service):
     service.run()
     service.create_tag.assert_not_called()
 
+
 def test_run_happy_path_complete(service, mock_github, mock_version_repo, versions):
-    # Setup
     mock_version_repo.find_all.return_value = versions
-    
-    # Configure tag_exists to return False (tags don't exist) for all repos
     service.tag_exists = MagicMock(return_value=False)
     service.create_tag = MagicMock()
-    
-    # Create mock GitHub repos
+
     mock_repo1 = MagicMock()
     mock_repo2 = MagicMock()
-    
-    # Setup get_repo to return the appropriate repo
+    mock_capoa = MagicMock()
+
     def get_repo_side_effect(name):
         if name == "openshift/repo1":
             return mock_repo1
         elif name == "openshift/repo2":
             return mock_repo2
+        elif name == CAPOA_REPO:
+            return mock_capoa
         else:
             return MagicMock()
-            
+
     mock_github.get_repo.side_effect = get_repo_side_effect
-    
-    # Run the service
+
     service.run()
-    
-    # Verify the right repos were checked for existing tags
+
+    # Check that tag_exists was called for all openshift artifacts and for the CAPOA_REPO for each version
     expected_tag_exists_calls = [
-        call("openshift/repo1", "v1.0.0"),
-        call("openshift/repo2", "v1.0.0"),
-        call("openshift/repo1", "v1.1.0"),
-        call("openshift/repo2", "v1.1.0"),
+        call("openshift/repo1", "capoa-v1.0.0"),
+        call("openshift/repo2", "capoa-v1.0.0"),
+        call(CAPOA_REPO, "v1.0.0"),
+        call("openshift/repo1", "capoa-v1.1.0"),
+        call("openshift/repo2", "capoa-v1.1.0"),
+        call(CAPOA_REPO, "v1.1.0"),
     ]
-    service.tag_exists.assert_has_calls(expected_tag_exists_calls, any_order=True)
-    
-    # Verify that tags were created
+    for expected in expected_tag_exists_calls:
+        assert expected in service.tag_exists.call_args_list
+
     expected_create_tag_calls = [
-        call("openshift/repo1", "abc123", "v1.0.0"),
-        call("openshift/repo2", "def456", "v1.0.0"),
-        call("openshift/repo1", "jkl012", "v1.1.0"),
-        call("openshift/repo2", "mno345", "v1.1.0"),
+        ("openshift/repo1", "abc123", "capoa-v1.0.0"),
+        ("openshift/repo2", "def456", "capoa-v1.0.0"),
+        (CAPOA_REPO, "ref", "v1.0.0"),
+        ("openshift/repo1", "jkl012", "capoa-v1.1.0"),
+        ("openshift/repo2", "mno345", "capoa-v1.1.0"),
+        (CAPOA_REPO, "ref", "v1.1.0"),
     ]
-    service.create_tag.assert_has_calls(expected_create_tag_calls, any_order=True)
-    
-    # verify that non-openshift repos were skipped
+
+    create_tag_call_args = [c.args for c in service.create_tag.call_args_list]
+    for ec in expected_create_tag_calls:
+        assert ec in create_tag_call_args
+
+    # Non-openshift repos were skipped
     for call_args in service.tag_exists.call_args_list:
-        repo = call_args[0][0]
-        assert repo.startswith("openshift/"), f"Non-openshift repo {repo} was checked"
-    
-    # verify that empty version names were skipped
+        repo = call_args.args[0]
+        assert repo.startswith("openshift/") or repo == CAPOA_REPO, (
+            f"Non-openshift repo {repo} was checked"
+        )
+
+    # Empty version name warning
     assert service.logger.warning.called
-    empty_version_warning_found = any(
-        "Skipping version without name" in str(args) 
+    found = any(
+        "Skipping version without name" in str(args)
         for args, _ in service.logger.warning.call_args_list
     )
-    assert empty_version_warning_found, "Warning about empty version name not logged"
+    assert found
+
 
 def test_run_with_existing_tags(service, mock_version_repo, versions):
-    mock_version_repo.find_all.return_value = versions[:1]  # just use first version
-    
-    # tag exists for repo1, not for repo2
+    mock_version_repo.find_all.return_value = versions[:1]
+
     def tag_exists_side_effect(repo, tag):
-        return repo == "openshift/repo1"  
-        
+        # repo1 tag exists and CAPOA_REPO exists; repo2 does not
+        return repo in ("openshift/repo1", CAPOA_REPO)
+
     service.tag_exists = MagicMock(side_effect=tag_exists_side_effect)
     service.create_tag = MagicMock()
-    
     service.run()
-    
-    # assert tag creation was only called for repo2 (not repo1)
-    service.create_tag.assert_called_once_with("openshift/repo2", "def456", "v1.0.0")
+    # Only repo2 should get a tag; also CAPOA_REPO should be skipped as "exists"
+    expected_calls = [
+        call("openshift/repo2", "def456", "capoa-v1.0.0"),
+    ]
+    actual_calls = [c for c in service.create_tag.call_args_list]
+    # But, due to CAPOA_REPO, make sure it's not called for it if tag exists
+    assert actual_calls == expected_calls
+
 
 def test_run_with_tag_creation_failure(service, mock_version_repo, versions):
     mock_version_repo.find_all.return_value = versions[:1]
-    
     service.tag_exists = MagicMock(return_value=False)
-    
+
     def create_tag_side_effect(repo, ref, tag):
         if repo == "openshift/repo2":
             raise Exception(f"Failed to create tag {tag} on {repo}")
-            
+
     service.create_tag = MagicMock(side_effect=create_tag_side_effect)
-    
-    with pytest.raises(Exception, match="Failed to create tag v1.0.0 on openshift/repo2"):
+    with pytest.raises(
+        Exception, match="Failed to create tag capoa-v1.0.0 on openshift/repo2"
+    ):
         service.run()
-    
-    service.create_tag.assert_any_call("openshift/repo1", "abc123", "v1.0.0")
+    service.create_tag.assert_any_call("openshift/repo1", "abc123", "capoa-v1.0.0")
+
 
 def test_create_tag_implementation(service, mock_github):
-    # Bypass our mocking and test actual implementation
-    service.create_tag = TagReconciliationService.create_tag.__get__(service, TagReconciliationService)
-    
-    # Setup mock repo
+    service.create_tag = TagReconciliationService.create_tag.__get__(
+        service, TagReconciliationService
+    )
     mock_repo = MagicMock()
     mock_tag_obj = MagicMock()
     mock_tag_obj.sha = "tag_sha_123"
     mock_repo.create_git_tag.return_value = mock_tag_obj
     mock_github.get_repo.return_value = mock_repo
-    
-    service.create_tag("openshift/repo1", "commit_sha_123", "v1.0.0")
-    
+    service.create_tag("openshift/repo1", "commit_sha_123", "capoa-v1.0.0")
     mock_repo.create_git_tag.assert_called_once_with(
-        tag="v1.0.0", 
-        message="Tagged by CI", 
-        object="commit_sha_123", 
-        type="commit"
+        tag="capoa-v1.0.0",
+        message="Tagged by CI",
+        object="commit_sha_123",
+        type="commit",
     )
     mock_repo.create_git_ref.assert_called_once_with(
-        "refs/tags/v1.0.0", 
-        "tag_sha_123"
+        "refs/tags/capoa-v1.0.0", "tag_sha_123"
     )
 
+
 def test_tag_exists_implementation(service, mock_github):
-    service.tag_exists = TagReconciliationService.tag_exists.__get__(service, TagReconciliationService)
-    
+    service.tag_exists = TagReconciliationService.tag_exists.__get__(
+        service, TagReconciliationService
+    )
     mock_repo = MagicMock()
     mock_github.get_repo.return_value = mock_repo
-    
     mock_repo.get_git_ref.return_value = MagicMock()
-    assert service.tag_exists("openshift/repo1", "v1.0.0") is True
-    mock_repo.get_git_ref.assert_called_with("tags/v1.0.0")
-    
+    assert service.tag_exists("openshift/repo1", "capoa-v1.0.0") is True
+    mock_repo.get_git_ref.assert_called_with("tags/capoa-v1.0.0")
     mock_repo.get_git_ref.side_effect = Exception("Not found")
-    assert service.tag_exists("openshift/repo1", "v1.0.0") is False
+    assert service.tag_exists("openshift/repo1", "capoa-v1.0.0") is False
+
 
 def test_run_no_versions(service, mock_version_repo):
     mock_version_repo.find_all.return_value = []
-    
     service.tag_exists = MagicMock()
     service.create_tag = MagicMock()
-    
     service.run()
-    
     service.tag_exists.assert_not_called()
     service.create_tag.assert_not_called()
 
+
 def test_tag_already_exists_detailed(service, mock_github, mock_version_repo, versions):
-    mock_version_repo.find_all.return_value = versions[:1]  # Just use the first version (v1.0.0)
-    
-    # Setup GitHub repo responses
+    mock_version_repo.find_all.return_value = versions[:1]
     repo1 = MagicMock()
     repo2 = MagicMock()
-    
+    capoa_repo = MagicMock()
+
     def get_repo_side_effect(name):
         if name == "openshift/repo1":
             return repo1
         elif name == "openshift/repo2":
             return repo2
+        elif name == CAPOA_REPO:
+            return capoa_repo
         else:
             return MagicMock()
-    
+
     mock_github.get_repo.side_effect = get_repo_side_effect
-    
-    def get_git_ref_side_effect(ref_path):
-        if ref_path == "tags/v1.0.0" and repo1 == mock_github.get_repo("openshift/repo1"):
-            return MagicMock()
-        raise Exception("Tag not found")
-    
-    repo1.get_git_ref.side_effect = get_git_ref_side_effect
+    repo1.get_git_ref.return_value = MagicMock()
     repo2.get_git_ref.side_effect = Exception("Tag not found")
-    
+    capoa_repo.get_git_ref.return_value = MagicMock()
     original_create_tag = service.create_tag
     create_tag_calls = []
-    
+
     def spy_create_tag(repo, ref, tag):
         create_tag_calls.append((repo, ref, tag))
         return original_create_tag(repo, ref, tag)
-    
+
     service.create_tag = MagicMock(side_effect=spy_create_tag)
-    
     service.run()
-    
-    # assert that repo1 tag was NOT created (already exists), but repo2 tag was created
+    # repo1 and CAPOA_REPO tag exist, so only repo2 gets created
     assert len(create_tag_calls) == 1
-    assert create_tag_calls[0][0] == "openshift/repo2"  # Only repo2 should get a tag
-    assert create_tag_calls[0][2] == "v1.0.0"  # With version v1.0.0
-    
-    repo1.get_git_ref.assert_called_with("tags/v1.0.0")
-    repo2.get_git_ref.assert_called_with("tags/v1.0.0")
-    
+    assert create_tag_calls[0][0] == "openshift/repo2"
+    assert create_tag_calls[0][2] == "capoa-v1.0.0"
+    repo1.get_git_ref.assert_called_with("tags/capoa-v1.0.0")
+    repo2.get_git_ref.assert_called_with("tags/capoa-v1.0.0")
+    capoa_repo.get_git_ref.assert_called_with("tags/v1.0.0")
     log_messages = [args[0] for args, _ in service.logger.info.call_args_list]
-    repo2_message_found = any("Created tag v1.0.0 on openshift/repo2" in msg for msg in log_messages)
+    repo2_message_found = any(
+        "Created tag capoa-v1.0.0 on openshift/repo2" in msg for msg in log_messages
+    )
     assert repo2_message_found
 
-def test_tag_creation_failure_detailed(service, mock_github, mock_version_repo, versions):
-    mock_version_repo.find_all.return_value = versions[:1]  # Just use the first version (v1.0.0)
-    
-    # no tags exist
+
+def test_tag_creation_failure_detailed(
+    service, mock_github, mock_version_repo, versions
+):
+    mock_version_repo.find_all.return_value = versions[:1]
     mock_repo = MagicMock()
     mock_repo.get_git_ref.side_effect = Exception("Tag not found")
     mock_github.get_repo.return_value = mock_repo
-    
-    # setup create_git_tag to fail with a specific error for repo2
+
     def create_git_tag_side_effect(tag, message, object, type):
-        if tag == "v1.0.0" and "repo2" in str(mock_github.get_repo.call_args[0][0]):
+        if tag == "capoa-v1.0.0" and "repo2" in str(
+            mock_github.get_repo.call_args[0][0]
+        ):
             raise Exception("GitHub API error: Reference already exists")
         return MagicMock(sha="fake_sha")
-    
+
     mock_repo.create_git_tag.side_effect = create_git_tag_side_effect
-    
     with pytest.raises(Exception) as excinfo:
         service.run()
-    
-    # verify the error contains both the repo name and the original error
     error_message = str(excinfo.value)
-    assert "Failed to create tag v1.0.0 on openshift/repo2" in error_message
-    assert "GitHub API error: Reference already exists" in error_message
-    
-    # verify that tag creation was attempted for repo1 before failing on repo2
-    mock_repo.create_git_tag.assert_called_with(
-        tag="v1.0.0", 
-        message="Tagged by CI", 
-        object="def456",  # This is the ref for repo2 in our test data
-        type="commit"
+    assert (
+        "Failed to create tag capoa-v1.0.0 on openshift/repo2" in error_message
+        or "Failed to create tag capoa-v1.0.0 on https://github.com/openshift/repo2"
+        in error_message
     )
+    assert "GitHub API error: Reference already exists" in error_message
+
 
 def test_dry_run_mode(service, mock_version_repo, versions):
-    # Update fixture to use dry_run=True
     service.dry_run = True
-    mock_version_repo.find_all.return_value = versions[:1]  # Just use the first version (v1.0.0)
-    
-    # Configure tag_exists to return False (tags don't exist) for all repos
+    mock_version_repo.find_all.return_value = versions[:1]
     service.tag_exists = MagicMock(return_value=False)
     service.create_tag = MagicMock()
-    
-    # Run the service
     service.run()
-    
-    # Verify that create_tag was not called (most important check for dry run)
     service.create_tag.assert_not_called()
-    
-    # Verify the dry run log messages
     dry_run_messages = [
-        args[0] for args, kwargs in service.logger.info.call_args_list 
+        args[0]
+        for args, kwargs in service.logger.info.call_args_list
         if args and "Dry run mode" in args[0]
     ]
-    
-    # Check that we have dry run messages
     assert len(dry_run_messages) > 0
-    
-    # Check that we have the expected messages for each OpenShift artifact
     for artifact in versions[0].artifacts:
         if artifact.repository.startswith("https://github.com/openshift/"):
             repo = artifact.repository.replace("https://github.com/", "")
-            expected_msg = f"Dry run mode. tag v1.0.0 on {artifact.ref} in repo {repo} has not been created"
-            assert any(expected_msg in msg for msg in dry_run_messages), f"Expected log message not found for {repo}"
+            expected_msg = f"Dry run mode. tag capoa-v1.0.0 on {artifact.ref} in repo {repo} has not been created"
+            assert any(expected_msg in msg for msg in dry_run_messages), (
+                f"Expected log message not found for {repo}"
+            )
+    # CAPOA_REPO dry run log
+    expected_msg_full = f"Dry run mode. tag v1.0.0 on ref in repo {CAPOA_REPO} has not been created"
+    assert any(expected_msg_full in msg for msg in dry_run_messages)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a pending snapshot for testing via a new command-line option and enhanced script logic.
  - Snapshots and versions now include an optional field to indicate the reference they were tested with.
  - Tag reconciliation now ensures tags are created with a new "capoa-" prefix and applies to an additional repository.

- **Bug Fixes**
  - Improved handling of pending snapshots and git references during testing and tagging processes.

- **Tests**
  - Enhanced and streamlined tests for artifact setup, tag reconciliation, and dry run scenarios.
  - Updated tests to cover the new repository and tag naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->