### PR TITLE
Add renovate.json to prevent dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+    "schedule": ["on Saturday"],
+    "groupName": "Konflux build pipeline",
+    "includePaths": [".tekton/*"],
+    "commitMessagePrefix": "NO-ISSUE: ",
+    "labels": ["lgtm", "approved"]
+}


### PR DESCRIPTION
Forgot that this needs to be on the default branch, not the release branch.

This should solve the issue I was trying to solve with https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted/pull/165


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated dependency update configuration to streamline updates within the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->