### PR TITLE
add necessary capabilities

### DIFF
--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -54,7 +54,7 @@ const (
 )
 
 var (
-	defaultBaremetalAdditionalCapabilities = []configv1.ClusterVersionCapability{"baremetal", "Console", "Insights", "OperatorLifecycleManager", "Ingress"}
+	defaultBaremetalAdditionalCapabilities = []configv1.ClusterVersionCapability{"baremetal", "Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig"}
 )
 
 // ClusterDeploymentReconciler reconciles a ClusterDeployment object

--- a/controlplane/internal/controller/clusterdeployment_controller_test.go
+++ b/controlplane/internal/controller/clusterdeployment_controller_test.go
@@ -204,7 +204,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 				Expect(aci.Spec.IngressVIPs).To(Equal(ingressVIPs))
 				Expect(aci.Spec.APIVIPs).To(Equal(apiVIPs))
 				Expect(aci.Annotations).To(HaveKey(InstallConfigOverrides))
-				Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress"]}}`))
+				Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
 			})
 		})
 	})
@@ -245,12 +245,12 @@ var _ = Describe("ClusterDeployment Controller", func() {
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cd), aci)).To(Succeed())
 					By("Verifying the ACI has the default install config overrides for baremetal set in its annotations")
 					Expect(aci.Annotations).To(HaveKey(InstallConfigOverrides))
-					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress"]}}`))
+					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
 				})
 			})
 			When("additional capabilities are specified", func() {
 				It("ACI should have default baremetal install config override annotation along with the additional capabilities", func() {
-					oacp.Spec.Config.Capabilities = v1alpha2.Capabilities{AdditionalEnabledCapabilities: []string{"NodeTuning"}}
+					oacp.Spec.Config.Capabilities = v1alpha2.Capabilities{AdditionalEnabledCapabilities: []string{"CloudControllerManager"}}
 					Expect(k8sClient.Update(ctx, oacp)).To(Succeed())
 					_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 						NamespacedName: client.ObjectKeyFromObject(cd),
@@ -262,7 +262,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal and the additional capability set in its annotations")
 					Expect(aci.Annotations).To(HaveKey(InstallConfigOverrides))
-					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","NodeTuning"]}}`))
+					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
 				})
 			})
 			When("additional capabilities are the same as the default baremetal capabilities", func() {
@@ -280,12 +280,12 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal without duplicates")
 					Expect(aci.Annotations).To(HaveKey(InstallConfigOverrides))
-					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress"]}}`))
+					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
 				})
 			})
 			When("additional capabilities include MAPI", func() {
 				It("ACI should have default baremetal install config override annotation without MAPI", func() {
-					oacp.Spec.Config.Capabilities = v1alpha2.Capabilities{AdditionalEnabledCapabilities: []string{"MachineAPI", "NodeTuning"}}
+					oacp.Spec.Config.Capabilities = v1alpha2.Capabilities{AdditionalEnabledCapabilities: []string{"MachineAPI", "CloudControllerManager"}}
 					Expect(k8sClient.Update(ctx, oacp)).To(Succeed())
 
 					_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -298,7 +298,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal without MAPI")
 					Expect(aci.Annotations).To(HaveKey(InstallConfigOverrides))
-					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","NodeTuning"]}}`))
+					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
 				})
 			})
 			When("only baseline capability is specified", func() {
@@ -316,7 +316,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the correct install config overrides for baremetal and the specified baseline capability")
 					Expect(aci.Annotations).To(HaveKey(InstallConfigOverrides))
-					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"vCurrent","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress"]}}`))
+					Expect(aci.Annotations[InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"vCurrent","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
 				})
 			})
 		})


### PR DESCRIPTION
Default baremetal platform has those capabilities: let's add them for an improved day-0 experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the default capabilities for baremetal clusters to include "marketplace", "NodeTuning", and "DeploymentConfig".

- **Tests**
	- Updated tests to reflect the expanded set of default capabilities for baremetal clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->