### PR TITLE
Mgmt 20822 kernelargs to coreos installer args

### DIFF
--- a/assistedinstaller/infraenv.go
+++ b/assistedinstaller/infraenv.go
@@ -44,7 +44,6 @@ func GetInfraEnvFromConfig(
 			Namespace: clusterDeployment.Namespace,
 		},
 		CpuArchitecture:            config.Spec.CpuArchitecture,
-		KernelArguments:            config.Spec.KernelArguments,
 		NMStateConfigLabelSelector: config.Spec.NMStateConfigLabelSelector,
 		OSImageVersion:             config.Spec.OSImageVersion,
 		Proxy:                      config.Spec.Proxy,

--- a/bootstrap/internal/controller/openshiftassistedconfig_controller_test.go
+++ b/bootstrap/internal/controller/openshiftassistedconfig_controller_test.go
@@ -405,7 +405,6 @@ func assertInfraEnvSpecs(infraEnv v1beta1.InfraEnv, oac *bootstrapv1alpha1.Opens
 	Expect(infraEnv.Spec.AdditionalNTPSources).To(Equal(oac.Spec.AdditionalNTPSources))
 	Expect(infraEnv.Spec.NMStateConfigLabelSelector).To(Equal(oac.Spec.NMStateConfigLabelSelector))
 	Expect(infraEnv.Spec.CpuArchitecture).To(Equal(oac.Spec.CpuArchitecture))
-	Expect(infraEnv.Spec.KernelArguments).To(Equal(oac.Spec.KernelArguments))
 	Expect(infraEnv.Spec.AdditionalTrustBundle).To(Equal(oac.Spec.AdditionalTrustBundle))
 	Expect(infraEnv.Spec.OSImageVersion).To(Equal(oac.Spec.OSImageVersion))
 }
@@ -454,16 +453,6 @@ func setupControlPlaneOpenshiftAssistedConfig(
 		},
 	}
 	oac.Spec.CpuArchitecture = "x86"
-	oac.Spec.KernelArguments = []v1beta1.KernelArgument{
-		{
-			Operation: "append",
-			Value:     "p1",
-		},
-		{
-			Operation: "append",
-			Value:     `p2="this is an argument"`,
-		},
-	}
 	oac.Spec.AdditionalTrustBundle = testCert
 	oac.Spec.OSImageVersion = "4.14.0"
 	Expect(k8sClient.Create(ctx, oac)).To(Succeed())


### PR DESCRIPTION
Bootstrap config spec.KernelArgs should map to the final openshift node, not to the discovery phase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Installer arguments for agents now support kernel arguments specified in the bootstrap configuration, automatically formatting them as CoreOS install arguments.

- **Bug Fixes**
  - Removed outdated handling and assertions related to kernel arguments in infrastructure environment and configuration tests to ensure consistency with the updated logic.

- **Tests**
  - Added a new test to verify that kernel arguments from the bootstrap configuration are correctly propagated to agent installer arguments during reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->