### PR TITLE
MGMT-20825: add discovery ignition annotation

### DIFF
--- a/assistedinstaller/infraenv.go
+++ b/assistedinstaller/infraenv.go
@@ -1,6 +1,7 @@
 package assistedinstaller
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -52,6 +53,11 @@ func GetInfraEnvFromConfig(
 		SSHAuthorizedKey:           config.Spec.SSHAuthorizedKey,
 		// Must be full-iso to ensure static networking settings is generated in the ignition
 		ImageType: "full-iso",
+	}
+	annotations := config.GetAnnotations()
+	if ignitionOverride, ok := annotations[bootstrapv1alpha1.DiscoveryIgnitionOverrideAnnotation]; ok &&
+		json.Valid([]byte(ignitionOverride)) {
+		infraEnv.Spec.IgnitionConfigOverride = ignitionOverride
 	}
 	return infraEnv
 }

--- a/bootstrap/api/v1alpha1/openshiftassistedconfig_types.go
+++ b/bootstrap/api/v1alpha1/openshiftassistedconfig_types.go
@@ -23,8 +23,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+const DiscoveryIgnitionOverrideAnnotation = "openshiftassistedconfig.cluster.x-k8s.io/discovery-ignition-override"
 
 // OpenshiftAssistedConfigSpec defines the desired state of OpenshiftAssistedConfig
 type OpenshiftAssistedConfigSpec struct {


### PR DESCRIPTION
Expose discovery ignition override through annotations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for overriding the ignition configuration in InfraEnv when a valid discovery ignition override annotation is present.

- **Tests**
  - Introduced new test cases to verify InfraEnv generation, including handling of discovery ignition override annotations with valid and invalid JSON.

- **Chores**
  - Added a new constant for the discovery ignition override annotation key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->