### PR TITLE
Enable CGO for FIPS compliance

### DIFF
--- a/Dockerfile.bootstrap-provider
+++ b/Dockerfile.bootstrap-provider
@@ -24,7 +24,7 @@ COPY bootstrap/internal/ bootstrap/internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager bootstrap/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager bootstrap/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /

--- a/Dockerfile.controlplane-provider
+++ b/Dockerfile.controlplane-provider
@@ -24,7 +24,7 @@ COPY controlplane/internal/ controlplane/internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager controlplane/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager controlplane/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -24,7 +24,7 @@ COPY {{ provider }}/internal/ {{ provider }}/internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager {{ provider }}/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -mod=vendor -a -o manager {{ provider }}/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /


### PR DESCRIPTION
Forgot that this repo had similar release branch dockerfiles.
Also fixing this here so that we don't regress in 2.10