### PR TITLE
Mgmt 20822 kernelargs to coreos installer args backport 2.9

### DIFF
--- a/assistedinstaller/infraenv.go
+++ b/assistedinstaller/infraenv.go
@@ -45,7 +45,6 @@ func GetInfraEnvFromConfig(
 			Namespace: clusterDeployment.Namespace,
 		},
 		CpuArchitecture:            config.Spec.CpuArchitecture,
-		KernelArguments:            config.Spec.KernelArguments,
 		NMStateConfigLabelSelector: config.Spec.NMStateConfigLabelSelector,
 		OSImageVersion:             config.Spec.OSImageVersion,
 		Proxy:                      config.Spec.Proxy,

--- a/bootstrap/internal/controller/openshiftassistedconfig_controller_test.go
+++ b/bootstrap/internal/controller/openshiftassistedconfig_controller_test.go
@@ -405,7 +405,6 @@ func assertInfraEnvSpecs(infraEnv v1beta1.InfraEnv, oac *bootstrapv1alpha1.Opens
 	Expect(infraEnv.Spec.AdditionalNTPSources).To(Equal(oac.Spec.AdditionalNTPSources))
 	Expect(infraEnv.Spec.NMStateConfigLabelSelector).To(Equal(oac.Spec.NMStateConfigLabelSelector))
 	Expect(infraEnv.Spec.CpuArchitecture).To(Equal(oac.Spec.CpuArchitecture))
-	Expect(infraEnv.Spec.KernelArguments).To(Equal(oac.Spec.KernelArguments))
 	Expect(infraEnv.Spec.AdditionalTrustBundle).To(Equal(oac.Spec.AdditionalTrustBundle))
 	Expect(infraEnv.Spec.OSImageVersion).To(Equal(oac.Spec.OSImageVersion))
 }
@@ -454,16 +453,6 @@ func setupControlPlaneOpenshiftAssistedConfig(
 		},
 	}
 	oac.Spec.CpuArchitecture = "x86"
-	oac.Spec.KernelArguments = []v1beta1.KernelArgument{
-		{
-			Operation: "append",
-			Value:     "p1",
-		},
-		{
-			Operation: "append",
-			Value:     `p2="this is an argument"`,
-		},
-	}
 	oac.Spec.AdditionalTrustBundle = testCert
 	oac.Spec.OSImageVersion = "4.14.0"
 	Expect(k8sClient.Create(ctx, oac)).To(Succeed())


### PR DESCRIPTION
Backport of https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted/pull/246/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive Tekton PipelineRun configurations for multi-architecture container image builds, security scans, and compliance checks, triggered on both push and pull request events for specific components.
  - Introduced new Renovate configuration to automate dependency updates in the build pipeline.

- **Enhancements**
  - Dockerfiles now enable CGO for Go builds and include richer container metadata via new environment variables and labels.

- **Bug Fixes**
  - Improved handling of ignition config overrides and kernel arguments in InfraEnv and Agent resources, with added resilience to invalid input.

- **Tests**
  - Added and updated test cases to verify correct handling of kernel arguments and ignition config overrides.

- **Chores**
  - Updated release candidate metadata for improved tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->