### PR TITLE
Update trivy-action to v0.32.0 in security-scan.yaml

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -26,19 +26,19 @@ jobs:
         run: |
           mkdir -p scans/
       - name: Run Trivy vulnerability scanner for controlplane
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: 'quay.io/edge-infrastructure/cluster-api-controlplane-provider-openshift-assisted:${{ github.sha }}'
           trivy-config: .trivy.yaml
           output: 'scans/trivy-results-controlplane.sarif'
       - name: Run Trivy vulnerability scanner for bootstrap
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: 'quay.io/edge-infrastructure/cluster-api-bootstrap-provider-openshift-assisted:${{ github.sha }}'
           trivy-config: .trivy.yaml
           output: 'scans/trivy-results-bootstrap.sarif'
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           scan-type: 'fs'
           output: 'trivy-results-repo.sarif'

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -54,8 +54,3 @@ jobs:
         with:
           scan-type: 'fs'
           output: 'trivy-results-repo.sarif'
-      - name: Upload Trivy repo scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: 'trivy-results-repo.sarif'

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -31,19 +31,31 @@ jobs:
           image-ref: 'quay.io/edge-infrastructure/cluster-api-controlplane-provider-openshift-assisted:${{ github.sha }}'
           trivy-config: .trivy.yaml
           output: 'scans/trivy-results-controlplane.sarif'
+      - name: Upload Trivy scan results for controlplane to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'scans/trivy-results-controlplane.sarif'
+          category: 'controlplane'
       - name: Run Trivy vulnerability scanner for bootstrap
         uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: 'quay.io/edge-infrastructure/cluster-api-bootstrap-provider-openshift-assisted:${{ github.sha }}'
           trivy-config: .trivy.yaml
           output: 'scans/trivy-results-bootstrap.sarif'
+      - name: Upload Trivy scan results for bootstrap to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'scans/trivy-results-controlplane.sarif'
+          category: 'bootstrap'
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.32.0
         with:
           scan-type: 'fs'
           output: 'trivy-results-repo.sarif'
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Trivy repo scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
-          sarif_file: 'scans/'
+          sarif_file: 'trivy-results-repo.sarif'


### PR DESCRIPTION
Multiple runs in one SARIF file are no longer allowed per https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

Test updating the version of trivy-action to see if it adheres to this.

Uploading individual scan files one at a time instead of the whole folder at once will pass this new rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow to use a newer version of the vulnerability scanner, ensuring improved security checks.
  * Enhanced the upload process for security scan results to the GitHub Security tab for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->