### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-api-provider-openshift-assisted-bootstrap-mce-29

### DIFF
--- a/Dockerfile.bootstrap-provider
+++ b/Dockerfile.bootstrap-provider
@@ -33,9 +33,10 @@ ENV SUMMARY="The OpenShift Assisted bootstrap provider for use when installing O
     DESCRIPTION="The OpenShift Assisted bootstrap provider implements the CAPI bootstrap provider contract and allows installing OpenShift by integrating with Assisted Installer"
 
 
-LABEL name="cluster-api-provider-openshift-assisted-bootstrap" \
+LABEL name="multicluster-engine/capoa-bootstrap-rhel9" \
       summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       com.redhat.component="cluster-api-provider-openshift-assisted-bootstrap" \
       io.k8s.display-name="OpenShift Assisted cluster API bootstrap provider" \
       io.k8s.description="${DESCRIPTION}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
