### PR TITLE
KONFLUX-6210: fix and set name and cpe label for cluster-api-provider-openshift-assisted-control-plane-mce-29

### DIFF
--- a/Dockerfile.controlplane-provider
+++ b/Dockerfile.controlplane-provider
@@ -33,9 +33,10 @@ ENV SUMMARY="The OpenShift Assisted controlplane provider for use when installin
     DESCRIPTION="The OpenShift Assisted controlplane provider implements the CAPI controlplane provider contract and allows installing OpenShift by integrating with Assisted Installer"
 
 
-LABEL name="cluster-api-provider-openshift-assisted-controlplane" \
+LABEL name="multicluster-engine/capoa-control-plane-rhel9" \
       summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       com.redhat.component="cluster-api-provider-openshift-assisted-controlplane" \
       io.k8s.display-name="OpenShift Assisted cluster API controlplane provider" \
       io.k8s.description="${DESCRIPTION}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
