### PR TITLE
do not wait for cooldown time when waiting for infraenv

### DIFF
--- a/bootstrap/api/v1alpha1/condition_consts.go
+++ b/bootstrap/api/v1alpha1/condition_consts.go
@@ -12,5 +12,5 @@ const (
 	DataSecretAvailableCondition          clusterv1.ConditionType = "DataSecretAvailable"
 	PullSecretAvailableCondition          clusterv1.ConditionType = "PullSecretAvailable"
 	OpenshiftAssistedConfigLabel                                  = "bootstrap.cluster.x-k8s.io/openshiftAssistedConfig"
-	InfraEnvCooldownReason                                        = "WaitingForInfraEnvToBeReady"
+	InfraEnvNotReadyReason                                        = "WaitingForInfraEnvToBeReady"
 )

--- a/bootstrap/internal/controller/openshiftassistedconfig_controller_test.go
+++ b/bootstrap/internal/controller/openshiftassistedconfig_controller_test.go
@@ -207,7 +207,7 @@ var _ = Describe("OpenshiftAssistedConfig Controller", func() {
 			})
 		})
 		When("ClusterDeployment and AgentClusterInstall are already created", func() {
-			It("should create infraenv with a CreatedAt time not past cooldown", func() {
+			It("should create infraenv with no EventsURL", func() {
 				oac := setupControlPlaneOpenshiftAssistedConfigWithPullSecretRef(ctx, k8sClient)
 				mockControlPlaneInitialization(ctx, k8sClient)
 
@@ -220,7 +220,7 @@ var _ = Describe("OpenshiftAssistedConfig Controller", func() {
 					bootstrapv1alpha1.DataSecretAvailableCondition,
 				)
 				Expect(dataSecretReadyCondition).NotTo(BeNil())
-				Expect(dataSecretReadyCondition.Reason).To(Equal(bootstrapv1alpha1.InfraEnvCooldownReason))
+				Expect(dataSecretReadyCondition.Reason).To(Equal(bootstrapv1alpha1.InfraEnvNotReadyReason))
 
 				assertThereAreMatchingInfraEnvs(ctx, k8sClient, oac)
 			})
@@ -239,7 +239,7 @@ var _ = Describe("OpenshiftAssistedConfig Controller", func() {
 					_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 						NamespacedName: client.ObjectKeyFromObject(oac),
 					})
-					Expect(err).To(MatchError("error while retrieving ignitionURL: cannot generate ignition url if events URL is not generated"))
+					Expect(err).To(MatchError(HavePrefix("infraenv not ready yet. CreatedTime")))
 				})
 			},
 		)


### PR DESCRIPTION
As we are not generating ISO, no need to wait for CreatedTime + cooldown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Readiness now depends on InfraEnv Events URL availability instead of a time-based cooldown, providing more accurate not-ready signaling and clearer error messages.

- Refactor
  - Replaced reason identifier InfraEnvCooldownReason with InfraEnvNotReadyReason (value unchanged) across status reporting.
  - Removed ignition cooldown gating in favor of Events URL readiness checks.

- Tests
  - Updated test expectations to reflect Events URL–based readiness and the new not-ready reason and error wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->