### PR TITLE
change download url for kubectl

### DIFF
--- a/test/playbooks/roles/kind_setup/tasks/main.yaml
+++ b/test/playbooks/roles/kind_setup/tasks/main.yaml
@@ -85,7 +85,7 @@
   ansible.builtin.command:
     cmd: >-
       curl -4 -fsSL -o /usr/local/bin/kubectl
-      "https://cdn.dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+      "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
   when: >
     kubectl_version_check.stdout is not defined or
     kubectl_version_check.stdout | length == 0 or


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kubectl binary download source for improved reliability in setup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->