### PR TITLE
Fix DNS resolution: preserve original nameservers in resolv.conf

### DIFF
--- a/test/e2e/libvirt/network-bmh-onlynameserver.xml.j2
+++ b/test/e2e/libvirt/network-bmh-onlynameserver.xml.j2
@@ -13,7 +13,8 @@
     </dhcp>
   </ip>
   <dnsmasq:options>
-    <dnsmasq:option value='server=/registry-proxy.engineering.redhat.com/10.11.5.160'/>
-    <dnsmasq:option value='server=8.8.8.8'/>
+{% for dns in host_dns_servers %}
+    <dnsmasq:option value='server={{ dns }}'/>
+{% endfor %}
   </dnsmasq:options>
 </network>

--- a/test/e2e/libvirt/network-bmh.xml.j2
+++ b/test/e2e/libvirt/network-bmh.xml.j2
@@ -36,7 +36,8 @@
 {% endif %}
     <dnsmasq:option value='address=/assisted-service.assisted-installer.com/{{ loadbalancer_ip }}'/>
     <dnsmasq:option value='address=/assisted-image.assisted-installer.com/{{ loadbalancer_ip }}'/>
-    <dnsmasq:option value='server=/registry-proxy.engineering.redhat.com/10.11.5.160'/>
-    <dnsmasq:option value='server=8.8.8.8'/>
+{% for dns in host_dns_servers %}
+    <dnsmasq:option value='server={{ dns }}'/>
+{% endfor %}
   </dnsmasq:options>
 </network>

--- a/test/playbooks/roles/network_setup/tasks/main.yaml
+++ b/test/playbooks/roles/network_setup/tasks/main.yaml
@@ -3,36 +3,60 @@
   ansible.builtin.command: hostname -I
   register: hostname_output
   changed_when: false
+
 - name: Set internal IP fact
   ansible.builtin.set_fact:
     internal_ip: "{{ hostname_output.stdout.split() | select('match', '^10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$') | first }}"
+
+- name: Get host DNS servers from NetworkManager
+  ansible.builtin.command: nmcli --terse --get-values IP4.DNS device show
+  register: nm_dns_output
+  changed_when: false
+  failed_when: false
+
+- name: Set host DNS servers from NetworkManager
+  ansible.builtin.set_fact:
+    host_dns_servers: "{{ nm_dns_output.stdout.split() | select('match', '^\\d') | unique | list }}"
+  when: nm_dns_output.stdout | trim | length > 0
+
+- name: Fallback - get host DNS servers from /etc/resolv.conf
+  ansible.builtin.shell: set -o pipefail && grep '^nameserver' /etc/resolv.conf | awk '{print $2}'
+  register: resolv_conf_output
+  changed_when: false
+  when: host_dns_servers is not defined or host_dns_servers | length == 0
+
+- name: Set host DNS servers from resolv.conf
+  ansible.builtin.set_fact:
+    host_dns_servers: "{{ resolv_conf_output.stdout_lines | select('match', '^\\d') | unique | list }}"
+  when: host_dns_servers is not defined or host_dns_servers | length == 0
+
 - name: Configure containers.conf
   ansible.builtin.copy:
     dest: /etc/containers/containers.conf
     mode: '0644'
     content: |
       [containers]
-      dns_servers = ["192.168.222.1", "8.8.8.8"]
+      dns_servers = ["192.168.222.1"{% for dns in host_dns_servers %}, "{{ dns }}"{% endfor %}]
       pids_limit = -1
+
 - name: Restart podman service
   ansible.builtin.systemd_service:
     state: restarted
     daemon_reload: true
     name: podman
+
 # create libvirt network with dns server (only recursive)
 - name: Start libvirt network
   community.libvirt.virt_net:
     state: absent
     name: bmh
-- name: Read libvirt network XML
-  ansible.builtin.slurp:
-    src: "{{ src_dir }}/test/e2e/libvirt/network-bmh-onlynameserver.xml"
-  register: network_xml_slurp
+
 - name: Define libvirt network from XML
   community.libvirt.virt_net:
     command: define
     name: bmh
-    xml: "{{ network_xml_slurp.content | b64decode }}"
+    xml: "{{ lookup('template', playbook_dir ~ '/../e2e/libvirt/network-bmh-onlynameserver.xml.j2') }}"
+
 - name: Start libvirt network
   community.libvirt.virt_net:
     state: active
@@ -44,4 +68,6 @@
     dest: /etc/resolv.conf
     content: |
       nameserver 192.168.222.1
-      nameserver 8.8.8.8
+      {% for dns in host_dns_servers %}
+      nameserver {{ dns }}
+      {% endfor %}


### PR DESCRIPTION
The network_setup role was overwriting /etc/resolv.conf with only the libvirt bridge DNS (192.168.222.1) and 8.8.8.8, discarding the original DNS servers from NetworkManager. This broke external DNS resolution (e.g. quay.io) on networks where 8.8.8.8 is blocked.

Now queries NetworkManager for the existing DNS servers and preserves them alongside the libvirt network nameserver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * DNS server configuration now discovers values from the host system dynamically instead of using hardcoded entries.
  * Generated network definitions and templates now populate upstream DNS entries from the discovered host DNS list rather than fixed addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->