### PR TITLE
Fix inject-provider-id script to expand environment variables

### DIFF
--- a/bootstrap/internal/ignition/ignition.go
+++ b/bootstrap/internal/ignition/ignition.go
@@ -465,11 +465,23 @@ set -euo pipefail
 PROVIDER_ID_FILE=/run/kubelet-provider-id
 DROPIN_DIR=/etc/systemd/system/kubelet.service.d
 DROPIN_FILE="${DROPIN_DIR}/20-provider-id.conf"
+METADATA_ENV_FILE=/etc/metadata_env
 
 PROVIDER_ID=$(cat "$PROVIDER_ID_FILE" 2>/dev/null) || true
 if [ -z "$PROVIDER_ID" ]; then
     echo "inject-provider-id: no provider-id found, skipping"
     exit 0
+fi
+
+# Expand environment variables in the provider ID
+# Source metadata_env if it exists to resolve variables like $METADATA_UUID
+if [ -f "$METADATA_ENV_FILE" ]; then
+    # Source the metadata env file to make variables available
+    set -a
+    source "$METADATA_ENV_FILE"
+    set +a
+    # Use eval to expand variables in the provider ID string
+    PROVIDER_ID=$(eval echo "$PROVIDER_ID")
 fi
 
 # Extract the full ExecStart command from kubelet.service, joining

--- a/bootstrap/internal/ignition/ignition_test.go
+++ b/bootstrap/internal/ignition/ignition_test.go
@@ -680,6 +680,10 @@ var _ = Describe("Ignition utils", func() {
 
 			// Script reads provider-id from the runtime file
 			Expect(contentStr).To(ContainSubstring("/run/kubelet-provider-id"))
+			// Script sources metadata_env to expand environment variables
+			Expect(contentStr).To(ContainSubstring("/etc/metadata_env"))
+			Expect(contentStr).To(ContainSubstring("source"))
+			Expect(contentStr).To(ContainSubstring("eval echo"))
 			// Script inspects actual kubelet.service ExecStart at runtime, joining continuation lines
 			Expect(contentStr).To(ContainSubstring("systemctl cat kubelet.service"))
 			Expect(contentStr).To(ContainSubstring("awk"))


### PR DESCRIPTION
The inject-provider-id script was not properly expanding environment variables in the provider ID value before injecting it into the kubelet service configuration. This caused provider IDs containing variable references (e.g., "openstack://$METADATA_UUID") to be written literally to the kubelet configuration without expansion, resulting in kubelet receiving the unexpanded string "--provider-id=openstack:///" instead of the actual UUID value.

This fix updates the inject-provider-id script to:
1. Source /etc/metadata_env (created by configdrive-metadata.service) before processing the provider ID
2. Use eval to expand any environment variables in the provider ID value
3. Inject the fully expanded provider ID into kubelet configuration

The change ensures that provider IDs like "openstack://$METADATA_UUID" are properly resolved to values like "openstack://0854b65a-..." before being passed to kubelet via the --provider-id flag.

Updated tests to verify the script includes variable expansion logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider ID injection now supports conditional environment variable expansion from metadata files when available, with automatic fallback to original behavior if metadata files are absent.

* **Tests**
  * Added test coverage validating environment variable expansion in provider ID injection scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->