### PR TITLE
Fix stale dnsmasq PID file blocking libvirt network activation when rerunning test

### DIFF
--- a/test/playbooks/roles/bmh_setup/tasks/main.yaml
+++ b/test/playbooks/roles/bmh_setup/tasks/main.yaml
@@ -19,6 +19,16 @@
   vars:
     loadbalancer_ip: "{{ lookup('file', '/tmp/loadbalancer_ip') }}"
 
+- name: Remove stale dnsmasq PID file
+  ansible.builtin.file:
+    path: /run/libvirt/network/bmh.pid
+    state: absent
+
+- name: Restore SELinux context on /run/libvirt
+  ansible.builtin.command: restorecon -RF /run/libvirt
+  changed_when: false
+  failed_when: false
+
 - name: Activate network
   community.libvirt.virt_net:
     state: active

--- a/test/playbooks/roles/network_setup/tasks/main.yaml
+++ b/test/playbooks/roles/network_setup/tasks/main.yaml
@@ -57,6 +57,16 @@
     name: bmh
     xml: "{{ lookup('template', playbook_dir ~ '/../e2e/libvirt/network-bmh-onlynameserver.xml.j2') }}"
 
+- name: Remove stale dnsmasq PID file
+  ansible.builtin.file:
+    path: /run/libvirt/network/bmh.pid
+    state: absent
+
+- name: Restore SELinux context on /run/libvirt
+  ansible.builtin.command: restorecon -RF /run/libvirt
+  changed_when: false
+  failed_when: false
+
 - name: Start libvirt network
   community.libvirt.virt_net:
     state: active


### PR DESCRIPTION
Remove the stale /run/libvirt/network/bmh.pid file before starting the bmh network. 
Even though the playbook destroys the bmh network (state: absent) and redefines it, libvirt doesn't clean up the PID file.
When a previous run leaves dnsmasq's PID file behind, libvirt refuses to start the network with 
> "failed to open pidfile: File exists"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the reliability of network initialization by cleaning up any leftover system files before activating network services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->