### PR TITLE
Fix ansible_distribution deprecation warning

### DIFF
--- a/test/playbooks/roles/system_dependencies/tasks/main.yaml
+++ b/test/playbooks/roles/system_dependencies/tasks/main.yaml
@@ -1,22 +1,22 @@
 ---
 - name: Distribution
   ansible.builtin.debug:
-    msg: "{{ ansible_distribution }}"
+    msg: "{{ ansible_facts['distribution'] }}"
 - name: Install EPEL
   ansible.builtin.dnf:
     enablerepo: powertools
     name:
       - epel-release
-  when: ansible_distribution != "RedHat"
+  when: ansible_facts['distribution'] != "RedHat"
 - name: Install dependencies
   ansible.builtin.dnf:
     enablerepo: crb
     name: "{{ system_dependencies_packages }}"
-  when: ansible_distribution != "RedHat"
+  when: ansible_facts['distribution'] != "RedHat"
 - name: Install dependencies RHEL
   ansible.builtin.dnf:
     name: "{{ system_dependencies_packages }}"
-  when: ansible_distribution == "RedHat"
+  when: ansible_facts['distribution'] == "RedHat"
 - name: Enable libvirtd
   ansible.builtin.systemd_service:
     name: libvirtd


### PR DESCRIPTION
Use ansible_facts['distribution'] instead of the deprecated ansible_distribution injected variable to silence the INJECT_FACTS_AS_VARS deprecation warning from ansible-core 2.24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal system compatibility checks to use an alternative method for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->