### PR TITLE
Fix sushy-tools container conflict with pre-existing systemd service

### DIFF
--- a/test/playbooks/roles/baremetal_emulation/tasks/main.yaml
+++ b/test/playbooks/roles/baremetal_emulation/tasks/main.yaml
@@ -1,4 +1,14 @@
 ---
+- name: Gather service facts
+  ansible.builtin.service_facts:
+
+- name: Stop and disable existing sushy systemd service
+  ansible.builtin.systemd:
+    name: sushy-emulator.service
+    state: stopped
+    enabled: false
+  when: "'sushy-emulator.service' in services"
+
 - name: Creating sushy-tools-config
   ansible.builtin.copy:
     dest: "/tmp/sushy-emulator.conf"
@@ -9,9 +19,19 @@
       SUSHY_EMULATOR_LISTEN_PORT = 8000
       # The libvirt URI to use. This option enables libvirt driver.
       SUSHY_EMULATOR_LIBVIRT_URI = u"qemu:///system"
+
+- name: Pull sushy-tools image
+  ansible.builtin.command: podman pull quay.io/metal3-io/sushy-tools:latest
+  changed_when: true
+
+- name: Remove existing sushy-tools container
+  ansible.builtin.shell: podman rm -f sushy-tools; podman container cleanup sushy-tools 2>/dev/null; true
+  failed_when: false
+  changed_when: false
+
 - name: Start sushytools
   ansible.builtin.shell: |
-    podman rm -f sushy-tools && podman run --name sushy-tools --rm --network host --privileged -d \
+    podman run --name sushy-tools --rm --replace --network host --privileged -d \
     -v /var/run/libvirt:/var/run/libvirt:z \
     -v "/tmp/sushy-emulator.conf:/etc/sushy/sushy-emulator.conf:z" \
     -e SUSHY_EMULATOR_CONFIG=/etc/sushy/sushy-emulator.conf \


### PR DESCRIPTION
On servers where a sushy-emulator.service systemd unit is present, it may manage sushy-tools using a different image with an incompatible entrypoint (HTTPS instead of HTTP). When this service is running, our podman run fails with a container name conflict or uses the wrong cached image, causing the Redfish endpoint to be unreachable and BMH registration to fail.

This commit:
- Stops and disables the systemd service before starting our container (failed_when: false for environments where it does not exist)
- Explicitly pulls the correct metal3-io image to avoid using a stale cached image from a different source
- Cleans up existing container storage before starting
- Uses --replace flag as a fallback for name conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable baremetal emulation startup with safer cleanup of any existing emulator service and container instances.
  * Explicit image refresh before starting the emulator to ensure the latest image is used.
  * Container start logic updated to replace existing instances cleanly and suppress non-critical failures during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->