### PR TITLE
Update SNO examples to use latest API versions

### DIFF
--- a/examples/sno-example.yaml.j2
+++ b/examples/sno-example.yaml.j2
@@ -7,7 +7,7 @@ metadata:
   namespace: test-capi
 type: kubernetes.io/dockerconfigjson
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: test-sno
@@ -40,7 +40,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha2
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: OpenshiftAssistedControlPlane
 metadata:
   name: test-sno
@@ -53,8 +53,9 @@ spec:
       name: "pull-secret"
     sshAuthorizedKey: "{{ ssh_authorized_key }}"
     nodeRegistration:
+      name: "$METADATA_NAME"
       kubeletExtraLabels:
-        - 'metal3.io/uuid="${METADATA_UUID}"'
+      - metal3.io/uuid=$METADATA_UUID
   distributionVersion: {{ openshift_version }}
   config:
     baseDomain: lab.home

--- a/examples/sno-okd-example.yaml.j2
+++ b/examples/sno-okd-example.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: test-sno-okd
@@ -32,7 +32,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha2
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: OpenshiftAssistedControlPlane
 metadata:
   name: test-sno-okd
@@ -43,8 +43,9 @@ spec:
   openshiftAssistedConfigSpec:
     sshAuthorizedKey: "{{ ssh_authorized_key }}"
     nodeRegistration:
+      name: "$METADATA_NAME"
       kubeletExtraLabels:
-        - 'metal3.io/uuid="${METADATA_UUID}"'
+      - metal3.io/uuid=$METADATA_UUID
   distributionVersion: {{ openshift_version }}
   config:
     baseDomain: lab.home

--- a/test/playbooks/roles/assert_install/tasks/main.yaml
+++ b/test/playbooks/roles/assert_install/tasks/main.yaml
@@ -5,11 +5,11 @@
     name: "{{ cluster_name }}"
     namespace: "{{ test_namespace }}"
   register: aci_result
+  until: >-
+    aci_result.resources is defined and
+    aci_result.resources | length > 0
   retries: "{{ medium_retries | int }}"
   delay: "{{ medium_delay | int }}"
-  failed_when: >-
-    aci_result.resources is not defined or
-    aci_result.resources | length == 0
 
 - name: Wait for ACI to be installing
   kubernetes.core.k8s_info:


### PR DESCRIPTION
Update sno-example.yaml.j2 and sno-okd-example.yaml.j2 to use Cluster v1beta2 and OpenshiftAssistedControlPlane v1alpha3, consistent with the multinode examples. The v1beta1 Cluster resources trigger a CAPI conversion webhook that fails to resolve Metal3Cluster CRDs, breaking the e2e test framework.

Also update nodeRegistration format to match v1alpha3 schema: add name field and use unquoted label syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example configuration templates to align with current Kubernetes API versions for Cluster and Control Plane resources
  * Modified node registration settings and kubelet label configuration in SNO example templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->