### PR TITLE
Wait for Metal3Cluster CRD before applying cluster manifests

### DIFF
--- a/test/playbooks/roles/components_install/tasks/capi_mce.yaml
+++ b/test/playbooks/roles/components_install/tasks/capi_mce.yaml
@@ -388,3 +388,14 @@
   retries: "{{ medium_retries | int }}"
   delay: "{{ medium_delay | int }}"
   when: capm3_standalone
+
+- name: Wait for Metal3Cluster CRD to be established
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: metal3clusters.infrastructure.cluster.x-k8s.io
+    wait: true
+    wait_condition:
+      type: Established
+      status: "True"
+    wait_timeout: 300

--- a/test/playbooks/roles/components_install/tasks/capi_standard.yaml
+++ b/test/playbooks/roles/components_install/tasks/capi_standard.yaml
@@ -86,6 +86,17 @@
   ansible.builtin.command: "clusterctl init --core cluster-api:{{ capi_version }} --bootstrap - --control-plane - --infrastructure metal3:{{ capm3_version }}"
   changed_when: true
 
+- name: Wait for Metal3Cluster CRD to be established
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: metal3clusters.infrastructure.cluster.x-k8s.io
+    wait: true
+    wait_condition:
+      type: Established
+      status: "True"
+    wait_timeout: 300
+
 - name: Deploy CAPBOA
   kubernetes.core.k8s:
     definition: "{{ lookup('kubernetes.core.kustomize', dir=playbook_dir + '/../../test/e2e/manifests/capboa') }}"


### PR DESCRIPTION
With CAPI v1.11.3+, the Metal3Cluster CRD may not be fully established by the time the cluster_install role applies the example manifest. This causes a race condition where the Cluster resource fails to create because its infrastructure provider (Metal3Cluster) is not yet recognized by the API server.

Add a retry loop that waits for the Metal3Cluster CRD to reach the Established condition before proceeding with namespace creation and manifest application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced deployment automation to ensure Metal3Cluster prerequisites are fully established before proceeding with component installation, improving deployment reliability and reducing potential race conditions during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->