### PR TITLE
Quote distributionVersion and make OCP/RHCOS versions configurable

### DIFF
--- a/examples/multinode-example.yaml.j2
+++ b/examples/multinode-example.yaml.j2
@@ -56,7 +56,7 @@ spec:
       name: "$METADATA_NAME"
       kubeletExtraLabels:
       - metal3.io/uuid=$METADATA_UUID
-  distributionVersion: {{ openshift_version }}
+  distributionVersion: "{{ openshift_version }}"
   config:
     apiVIPs:
     - 192.168.222.40

--- a/examples/multinode-okd-example.yaml.j2
+++ b/examples/multinode-okd-example.yaml.j2
@@ -44,7 +44,7 @@ spec:
     nodeRegistration:
       kubeletExtraLabels:
       - 'metal3.io/uuid="${METADATA_UUID}"'
-  distributionVersion: {{ openshift_version }}
+  distributionVersion: "{{ openshift_version }}"
   config:
     apiVIPs:
     - 192.168.222.40

--- a/examples/multinode-v1alpha2-example.yaml.j2
+++ b/examples/multinode-v1alpha2-example.yaml.j2
@@ -63,7 +63,7 @@ spec:
       name: "$METADATA_NAME"
       kubeletExtraLabels:
       - metal3.io/uuid=$METADATA_UUID
-  distributionVersion: {{ openshift_version }}
+  distributionVersion: "{{ openshift_version }}"
   config:
     apiVIPs:
     - 192.168.222.40

--- a/examples/sno-example.yaml.j2
+++ b/examples/sno-example.yaml.j2
@@ -56,7 +56,7 @@ spec:
       name: "$METADATA_NAME"
       kubeletExtraLabels:
       - metal3.io/uuid=$METADATA_UUID
-  distributionVersion: {{ openshift_version }}
+  distributionVersion: "{{ openshift_version }}"
   config:
     baseDomain: lab.home
     pullSecretRef:

--- a/examples/sno-okd-example.yaml.j2
+++ b/examples/sno-okd-example.yaml.j2
@@ -46,7 +46,7 @@ spec:
       name: "$METADATA_NAME"
       kubeletExtraLabels:
       - metal3.io/uuid=$METADATA_UUID
-  distributionVersion: {{ openshift_version }}
+  distributionVersion: "{{ openshift_version }}"
   config:
     baseDomain: lab.home
     sshAuthorizedKey: "{{ ssh_authorized_key }}"

--- a/test/playbooks/run_test.yaml
+++ b/test/playbooks/run_test.yaml
@@ -1,21 +1,28 @@
 ---
 # Setup and run tests playbook
 #
-# Environment variables for conditional execution:
-#   SKIP_BUILD=true        - Skip building provider images
-#   SKIP_CAPI_INSTALL=true - Skip CAPI/MCE component installation (dependencies still installed)
-#   SKIP_CLUSTER=true      - Skip cluster manifest application and assertions
+# Environment variables:
+#   OPENSHIFT_VERSION=4.x.y  - OpenShift release to test (default: 4.20.0)
+#   RHCOS_IMAGE_URL=<url>    - RHCOS image location (default: 4.20.0 nutanix qcow2)
+#   SKIP_BUILD=true          - Skip building provider images
+#   SKIP_CAPI_INSTALL=true   - Skip CAPI/MCE component installation (dependencies still installed)
+#   SKIP_CLUSTER=true        - Skip cluster manifest application and assertions
 #
 # Examples:
 #   # Full test run (default)
 #   ansible-playbook -i inventories/local_host.yaml run_test.yaml
+#
+#   # Test a specific OCP version with matching RHCOS image
+#   OPENSHIFT_VERSION=4.21.9 RHCOS_IMAGE_URL=https://mirror.openshift.com/.../rhcos-4.21.3-x86_64-nutanix.x86_64.qcow2 \
+#     ansible-playbook -i inventories/local_host.yaml run_test.yaml
 #
 #   # Skip image build (use pre-built images)
 #   SKIP_BUILD=true ansible-playbook -i inventories/local_host.yaml run_test.yaml
 #
 #   # Demo mode: setup everything for manual MCE deployment and cluster provisioning
 #   # (infra, dependencies, BMH setup - but skip CAPI install and cluster provisioning)
-#   SKIP_BUILD=true SKIP_CAPI_INSTALL=true SKIP_CLUSTER=true ansible-playbook -i inventories/local_host.yaml run_test.yaml
+#   SKIP_BUILD=true SKIP_CAPI_INSTALL=true SKIP_CLUSTER=true \
+#     ansible-playbook -i inventories/local_host.yaml run_test.yaml
 #
 #   # Deploy components but skip cluster provisioning
 #   SKIP_CLUSTER=true ansible-playbook -i inventories/local_host.yaml run_test.yaml
@@ -58,9 +65,15 @@
     low_retries: 1
     extra_paths:
       - /usr/local/bin
-    openshift_version: "4.20.0"
-    rhcos_image_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.20/4.20.0/rhcos-4.20.0-x86_64-nutanix.x86_64.qcow2"
-    rhcos_checksum_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.20/4.20.0/sha256sum.txt
+    openshift_version: >-
+      {{ lookup('ansible.builtin.env', 'OPENSHIFT_VERSION') | default('4.20.0', true) }}
+    default_rhcos_image_url: >-
+      https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.20/4.20.0/rhcos-4.20.0-x86_64-nutanix.x86_64.qcow2
+    rhcos_image_url: >-
+      {{ lookup('ansible.builtin.env', 'RHCOS_IMAGE_URL') | default(default_rhcos_image_url, true) }}
+    rhcos_checksum_url: >-
+      {{ lookup('ansible.builtin.env', 'RHCOS_CHECKSUM_URL')
+         | default(rhcos_image_url | dirname ~ '/sha256sum.txt', true) }}
     # Conditional execution flags
     skip_build: "{{ lookup('ansible.builtin.env', 'SKIP_BUILD', default='false') | lower in ['true', '1', 'yes'] }}"
     skip_capi_install: "{{ lookup('ansible.builtin.env', 'SKIP_CAPI_INSTALL', default='false') | lower in ['true', '1', 'yes'] }}"


### PR DESCRIPTION
- Quote distributionVersion in all example templates to prevent YAML from parsing values like 4.21 as floats
- Make openshift_version and rhcos_image_url overridable via environment variables (OPENSHIFT_VERSION, RHCOS_IMAGE_URL)
- Derive rhcos_checksum_url from rhcos_image_url instead of maintaining a separate variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed distribution version formatting in example templates to ensure version strings are properly parsed.

* **Documentation**
  * Updated test playbooks to support environment-driven configuration for OpenShift version and RHCOS image URL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->