### PR TITLE
NO-ISSUE: Restrict Renovate/Mintmaker to non-FFWD branches

### DIFF
--- a/hack/branch
+++ b/hack/branch
@@ -120,8 +120,10 @@ fi
 
 if ! jq --indent 4 \
     --arg freeze_branch "${freeze_branch}" \
-    '(.packageRules[] | select(.groupName == "Konflux build pipeline") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | unique) |
-     (.packageRules[] | select(.groupName == "UBI Runtime Images") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | unique)' \
+    --arg next_branch "${next_branch}" \
+    '(.baseBranches) |= ((. // []) + [$freeze_branch] | map(select(. != $next_branch)) | unique) |
+     (.packageRules[] | select(.groupName == "Konflux build pipeline") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | map(select(. != $next_branch)) | unique) |
+     (.packageRules[] | select(.groupName == "UBI Runtime Images") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | map(select(. != $next_branch)) | unique)' \
     renovate.json > renovate.updated.json; then
     echo "Error: Failed to update renovate.json"
     rm -f renovate.updated.json

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,13 @@
         "lgtm",
         "approved"
     ],
+    "baseBranches": [
+        "master",
+        "backplane-2.9",
+        "backplane-2.10",
+        "backplane-2.11",
+        "backplane-2.17"
+    ],
     "prHourlyLimit": 0,
     "prConcurrentLimit": 0,
     "enabledManagers": [


### PR DESCRIPTION
Add top-level baseBranches to renovate.json to prevent Mintmaker from creating UBI/Konflux PRs against the FFWD branch. Update hack/branch to maintain baseBranches during release cuts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Renovate configuration to explicitly target specific branches (`master` and designated `backplane` versions) for dependency update pull requests.
  * Enhanced branch filtering logic to better manage dependency updates across multiple release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->