### PR TITLE
NO-ISSUE: Support two FFWD branches with self-healing

### DIFF
--- a/.github/workflows/release-branch-generator.yaml
+++ b/.github/workflows/release-branch-generator.yaml
@@ -31,63 +31,53 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Detect freeze version and determine next version
+      - name: Detect versions from sync-branch.yaml
         run: |
-          VERSION_REGEX='^[0-9]+\.[0-9]+$'
-          NEXT_VERSION=$(echo "${{ github.event.inputs.next_version }}" | xargs)
-          
-          # Find the latest backplane branch (freeze version) using version-aware sort
-          FREEZE_VERSION=$(git branch -r | grep -E 'origin/backplane-[0-9]+\.[0-9]+$' | sed 's|.*origin/backplane-||' | sort -V | tail -1)
-          
-          if [ -z "${FREEZE_VERSION}" ]; then
-            echo "::error::No existing backplane branches found. Cannot determine freeze version."
+          SYNC_FILE=".github/workflows/sync-branch.yaml"
+
+          CURRENT_FFWD=$(grep 'CURRENT_BRANCH:' "${SYNC_FILE}" | awk '{print $2}')
+          NEXT_FFWD=$(grep 'NEXT_BRANCH:' "${SYNC_FILE}" | awk '{print $2}')
+
+          if [ -z "${CURRENT_FFWD}" ] || [ -z "${NEXT_FFWD}" ]; then
+            echo "::error::Could not parse CURRENT_BRANCH/NEXT_BRANCH from ${SYNC_FILE}"
             exit 1
           fi
-          
-          FREEZE_BRANCH="backplane-${FREEZE_VERSION}"
-          echo "Detected freeze version: ${FREEZE_VERSION}"
-          echo "FREEZE_VERSION=${FREEZE_VERSION}" >> $GITHUB_ENV
-          
-          # Parse freeze version components
-          FREEZE_MAJOR=$(echo "${FREEZE_VERSION}" | cut -d. -f1)
-          FREEZE_MINOR=$(echo "${FREEZE_VERSION}" | cut -d. -f2)
-          
-          # Determine next version
-          if [ -n "${NEXT_VERSION}" ]; then
+
+          FREEZE_VERSION="${CURRENT_FFWD#backplane-}"
+          CURRENT_VERSION="${NEXT_FFWD#backplane-}"
+
+          CURRENT_MAJOR=$(echo "${CURRENT_VERSION}" | cut -d. -f1)
+          CURRENT_MINOR=$(echo "${CURRENT_VERSION}" | cut -d. -f2)
+
+          NEXT_VERSION=$(echo "${{ github.event.inputs.next_version }}" | xargs)
+          if [ -z "${NEXT_VERSION}" ]; then
+            NEXT_VERSION="${CURRENT_MAJOR}.$((CURRENT_MINOR + 1))"
+          else
+            VERSION_REGEX='^[0-9]+\.[0-9]+$'
             if ! [[ "${NEXT_VERSION}" =~ ${VERSION_REGEX} ]]; then
               echo "::error::Invalid next version format '${NEXT_VERSION}'. Expected format: major.minor"
               exit 1
             fi
-            
-            # Validate that NEXT_VERSION > FREEZE_VERSION
-            NEXT_MAJOR=$(echo "${NEXT_VERSION}" | cut -d. -f1)
-            NEXT_MINOR=$(echo "${NEXT_VERSION}" | cut -d. -f2)
-            
-            if [ "${NEXT_MAJOR}" -lt "${FREEZE_MAJOR}" ] || \
-               ([ "${NEXT_MAJOR}" -eq "${FREEZE_MAJOR}" ] && [ "${NEXT_MINOR}" -le "${FREEZE_MINOR}" ]); then
-              echo "::error::Next version '${NEXT_VERSION}' must be greater than freeze version '${FREEZE_VERSION}'"
-              exit 1
-            fi
-            
-            echo "Using explicit next version: ${NEXT_VERSION}"
-          else
-            # Calculate next version (freeze + 1)
-            NEXT_VERSION="${FREEZE_MAJOR}.$((FREEZE_MINOR + 1))"
-            echo "Calculated next version: ${NEXT_VERSION}"
           fi
-          
+
+          echo "Freeze: ${FREEZE_VERSION} (${CURRENT_FFWD})"
+          echo "Current: ${CURRENT_VERSION} (${NEXT_FFWD} promoted)"
+          echo "Next: ${NEXT_VERSION} (new pre-staged branch)"
+
+          echo "FREEZE_VERSION=${FREEZE_VERSION}" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
           echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
 
-      - name: Create release branch (clean copy of master)
+      - name: Create next branch from master
         run: |
           NEXT_BRANCH="backplane-${NEXT_VERSION}"
           git checkout master
           git pull
-          
+
           if git ls-remote --heads origin "${NEXT_BRANCH}" | grep -q "${NEXT_BRANCH}"; then
             echo "::warning::Branch ${NEXT_BRANCH} already exists and will be reset to master"
           fi
-          
+
           git checkout -B "${NEXT_BRANCH}"
           git push origin "${NEXT_BRANCH}" --force
         env:
@@ -95,11 +85,11 @@ jobs:
 
       - name: Create working branch and update files
         run: |
-          NEXT_BRANCH="backplane-${NEXT_VERSION}"
-          PR_BRANCH="mce-cutoff-${NEXT_BRANCH}"
+          CURRENT_BRANCH="backplane-${CURRENT_VERSION}"
+          PR_BRANCH="mce-cutoff-${CURRENT_BRANCH}"
           git checkout master
           git checkout -B "${PR_BRANCH}"
-          ./hack/branch "${NEXT_VERSION}" "${FREEZE_VERSION}"
+          ./hack/branch "${CURRENT_VERSION}" "${NEXT_VERSION}" "${FREEZE_VERSION}"
           git push origin "${PR_BRANCH}" --force
         env:
           CI: "true"
@@ -107,16 +97,16 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          NEXT_BRANCH="backplane-${NEXT_VERSION}"
-          PR_BRANCH="mce-cutoff-${NEXT_BRANCH}"
+          CURRENT_BRANCH="backplane-${CURRENT_VERSION}"
+          PR_BRANCH="mce-cutoff-${CURRENT_BRANCH}"
 
           PR_NUMBER=$(gh pr list --head "${PR_BRANCH}" --json number -q '.[0].number')
           if [ -z "$PR_NUMBER" ]; then
             gh pr create \
               --head "${PR_BRANCH}" \
               --base master \
-              --title "Release ${NEXT_BRANCH}" \
-              --body "Automated PR for release branch ${NEXT_BRANCH}. Freezing backplane-${FREEZE_VERSION}."
+              --title "Release ${CURRENT_BRANCH}" \
+              --body "Automated PR for release branch ${CURRENT_BRANCH}. Freezing backplane-${FREEZE_VERSION}."
           else
             echo "PR #${PR_NUMBER} already exists"
           fi

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -10,7 +10,8 @@ jobs:
   fast-forward:
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: backplane-5.0
+      CURRENT_BRANCH: backplane-5.0
+      NEXT_BRANCH: backplane-5.1
 
     steps:
       - name: Checkout repo
@@ -22,10 +23,25 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
-      - name: Fast-forward master commits into  ${{ env.TARGET_BRANCH }}
+      - name: Configure Git
         run: |
           git config --global user.email "capi-openshift-assisted@redhat.com"
           git config --global user.name "CAPOA GitHub Action"
-          git checkout "${TARGET_BRANCH}"
-          git merge --ff-only origin/master
-          git push origin "${TARGET_BRANCH}"
+
+      - name: Fast-forward ${{ env.CURRENT_BRANCH }}
+        run: |
+          git checkout "${CURRENT_BRANCH}"
+          if ! git merge --ff-only origin/master; then
+            echo "::warning::${CURRENT_BRANCH} diverged from master, resetting"
+            git reset --hard origin/master
+          fi
+          git push origin "${CURRENT_BRANCH}" --force-with-lease
+
+      - name: Fast-forward ${{ env.NEXT_BRANCH }}
+        run: |
+          git checkout "${NEXT_BRANCH}"
+          if ! git merge --ff-only origin/master; then
+            echo "::warning::${NEXT_BRANCH} diverged from master, resetting"
+            git reset --hard origin/master
+          fi
+          git push origin "${NEXT_BRANCH}" --force-with-lease

--- a/hack/branch
+++ b/hack/branch
@@ -1,75 +1,82 @@
 #!/bin/bash
 set -euo pipefail
 
-next_version=${1:-}
-freeze_version=${2:-}
+current_version=${1:-}
+next_version=${2:-}
+freeze_version=${3:-}
 
-# Fetch branches if needed
+SYNC_BRANCH_FILE=".github/workflows/sync-branch.yaml"
+
 if [[ "${CI:-}" != "true" ]]; then
     git fetch --all
 fi
 
-# Find the latest backplane branch (freeze version) if not provided
-if [[ -z "${freeze_version}" ]]; then
-    # Use version-aware sort to correctly order versions
-    freeze_version=$(git branch -r | grep -E 'origin/backplane-[0-9]+\.[0-9]+$' | sed 's|.*origin/backplane-||' | sort -V | tail -1)
-    
-    if [[ -z "${freeze_version}" ]]; then
-        echo "Error: No existing backplane branches found. Cannot determine freeze version."
+# Auto-detect versions from sync-branch.yaml if not all provided
+if [[ -z "${current_version}" || -z "${next_version}" || -z "${freeze_version}" ]]; then
+    if [ ! -f "${SYNC_BRANCH_FILE}" ]; then
+        echo "Error: ${SYNC_BRANCH_FILE} does not exist, cannot auto-detect versions"
         exit 1
     fi
-else
-    # Validate provided freeze_version format
-    if ! [[ "${freeze_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-        echo "Error: Invalid freeze version format '${freeze_version}'. Expected format: major.minor"
+
+    current_ffwd=$(grep 'CURRENT_BRANCH:' "${SYNC_BRANCH_FILE}" | awk '{print $2}' | sed 's/backplane-//')
+    next_ffwd=$(grep 'NEXT_BRANCH:' "${SYNC_BRANCH_FILE}" | awk '{print $2}' | sed 's/backplane-//')
+
+    if [[ -z "${current_ffwd}" || -z "${next_ffwd}" ]]; then
+        echo "Error: Could not parse CURRENT_BRANCH/NEXT_BRANCH from ${SYNC_BRANCH_FILE}"
         exit 1
     fi
-    
-    # Validate that the freeze branch exists
-    if ! git branch -r | grep -qE "origin/backplane-${freeze_version}$"; then
-        echo "Error: Branch 'origin/backplane-${freeze_version}' does not exist."
-        exit 1
-    fi
+
+    freeze_version="${current_ffwd}"
+    current_version="${next_ffwd}"
+
+    current_major=$(echo "${current_version}" | cut -d. -f1)
+    current_minor=$(echo "${current_version}" | cut -d. -f2)
+    next_version="${current_major}.$((current_minor + 1))"
+
+    echo "Auto-detected from ${SYNC_BRANCH_FILE}:"
+    echo "  Freeze: ${freeze_version} (was CURRENT_BRANCH)"
+    echo "  Current: ${current_version} (was NEXT_BRANCH, now promoted)"
+    echo "  Next: ${next_version} (new pre-staged branch)"
 fi
+
+VERSION_REGEX='^[0-9]+\.[0-9]+$'
+for v in current_version next_version freeze_version; do
+    val="${!v}"
+    if ! [[ "${val}" =~ ${VERSION_REGEX} ]]; then
+        echo "Error: Invalid ${v} format '${val}'. Expected format: major.minor"
+        exit 1
+    fi
+done
 
 freeze_branch="backplane-${freeze_version}"
-echo "Freeze version: ${freeze_version}"
-
-# Parse freeze version components
-freeze_major=$(echo "${freeze_version}" | cut -d. -f1)
-freeze_minor=$(echo "${freeze_version}" | cut -d. -f2)
-
-# Calculate or use explicit next version
-if [[ -n "${next_version}" ]]; then
-    # Validate format
-    if ! [[ "${next_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-        echo "Error: Invalid next version format '${next_version}'. Expected format: major.minor"
-        exit 1
-    fi
-    
-    # Validate that next_version > freeze_version
-    next_major=$(echo "${next_version}" | cut -d. -f1)
-    next_minor=$(echo "${next_version}" | cut -d. -f2)
-    
-    if [[ "${next_major}" -lt "${freeze_major}" ]] || \
-       ([[ "${next_major}" -eq "${freeze_major}" ]] && [[ "${next_minor}" -le "${freeze_minor}" ]]); then
-        echo "Error: Next version '${next_version}' must be greater than freeze version '${freeze_version}'"
-        exit 1
-    fi
-    
-    echo "Using explicit next version: ${next_version}"
-else
-    # Calculate next version (freeze + 1)
-    next_version="${freeze_major}.$((freeze_minor + 1))"
-    echo "Calculated next version: ${next_version}"
-fi
-
+current_branch="backplane-${current_version}"
 next_branch="backplane-${next_version}"
-pr_branch="mce-cutoff-${next_branch}"
+
+echo "Freeze: ${freeze_branch}"
+echo "Current: ${current_branch}"
+echo "Next: ${next_branch}"
+
+# Validate freeze branch exists
+if ! git branch -r | grep -qE "origin/backplane-${freeze_version}$"; then
+    echo "Error: Branch 'origin/backplane-${freeze_version}' does not exist."
+    exit 1
+fi
 
 if [[ "${CI:-}" != "true" ]]; then
     git checkout master
 
+    # Create current branch if it doesn't exist
+    if ! git branch -r | grep -qE "origin/${current_branch}$"; then
+        git checkout -b "${current_branch}"
+        read -p "Create (push) branch ${current_branch}? (y/n)? " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            git push upstream "${current_branch}"
+        fi
+        git checkout master
+    fi
+
+    # Create next branch
     git checkout -b "${next_branch}"
     read -p "Create (push) branch ${next_branch}? (y/n)? " -n 1 -r
     echo
@@ -78,10 +85,11 @@ if [[ "${CI:-}" != "true" ]]; then
     fi
 
     git checkout master
+    pr_branch="mce-cutoff-${current_branch}"
     git checkout -b "${pr_branch}"
 fi
 
-short_version=${next_version//.}
+short_version=${current_version//.}
 
 # Handle .tekton directory safely
 if [ -d ".tekton" ]; then
@@ -89,25 +97,25 @@ if [ -d ".tekton" ]; then
     for f in .tekton/*; do
         [ ! -e "$f" ] && continue
         tekton_files_found=true
-        
+
         filename=$(basename "$f")
         in="./.tekton/${filename}"
         out=$(echo "${in}" | sed "s/mce-[0-9]\+/mce-${short_version}/g")
-        
+
         if [ -f "${in}" ]; then
             [ "${in}" != "${out}" ] && git mv "${in}" "${out}"
             sed -i "s/mce-[0-9]\+/mce-${short_version}/g" "${out}"
-            sed -i "s/${freeze_branch}/${next_branch}/g" "${out}"
+            sed -i "s/${freeze_branch}/${current_branch}/g" "${out}"
             git add "${out}"
         fi
     done
-    
+
     [ "$tekton_files_found" = false ] && echo "Note: .tekton directory is empty, skipping"
 else
     echo "Note: .tekton directory does not exist, skipping"
 fi
 
-# add old branch to the renovate.json to target konflux updates, as it's no longer ffwd
+# Update renovate.json: add freeze branch, remove next branch (ffwd)
 if [ ! -f "renovate.json" ]; then
     echo "Error: renovate.json does not exist"
     exit 1
@@ -120,8 +128,10 @@ fi
 
 if ! jq --indent 4 \
     --arg freeze_branch "${freeze_branch}" \
-    '(.packageRules[] | select(.groupName == "Konflux build pipeline") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | unique) |
-     (.packageRules[] | select(.groupName == "UBI Runtime Images") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | unique)' \
+    --arg next_branch "${next_branch}" \
+    '(.baseBranches) |= ((. // []) + [$freeze_branch] | map(select(. != $next_branch)) | unique) |
+     (.packageRules[] | select(.groupName == "Konflux build pipeline") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | map(select(. != $next_branch)) | unique) |
+     (.packageRules[] | select(.groupName == "UBI Runtime Images") | .baseBranchPatterns) |= ((. // []) + [$freeze_branch] | map(select(. != $next_branch)) | unique)' \
     renovate.json > renovate.updated.json; then
     echo "Error: Failed to update renovate.json"
     rm -f renovate.updated.json
@@ -131,17 +141,18 @@ fi
 mv renovate.updated.json renovate.json
 git add renovate.json
 
-# Update sync-branch.yaml with validation
-SYNC_BRANCH_FILE=".github/workflows/sync-branch.yaml"
+# Update sync-branch.yaml
 if [ ! -f "${SYNC_BRANCH_FILE}" ]; then
     echo "Error: ${SYNC_BRANCH_FILE} does not exist"
     exit 1
 fi
 
-sed -i "s/TARGET_BRANCH: .*$/TARGET_BRANCH: ${next_branch}/g" "${SYNC_BRANCH_FILE}"
+sed -i "s/CURRENT_BRANCH: .*$/CURRENT_BRANCH: ${current_branch}/g" "${SYNC_BRANCH_FILE}"
+sed -i "s/NEXT_BRANCH: .*$/NEXT_BRANCH: ${next_branch}/g" "${SYNC_BRANCH_FILE}"
 
-if ! grep -q "TARGET_BRANCH: ${next_branch}" "${SYNC_BRANCH_FILE}"; then
-    echo "Error: Failed to update TARGET_BRANCH in ${SYNC_BRANCH_FILE}"
+if ! grep -q "CURRENT_BRANCH: ${current_branch}" "${SYNC_BRANCH_FILE}" || \
+   ! grep -q "NEXT_BRANCH: ${next_branch}" "${SYNC_BRANCH_FILE}"; then
+    echo "Error: Failed to update branches in ${SYNC_BRANCH_FILE}"
     exit 1
 fi
 
@@ -151,7 +162,7 @@ git add "${SYNC_BRANCH_FILE}"
 for df in Dockerfile.j2 Dockerfile.bootstrap-provider Dockerfile.controlplane-provider; do
     if [ -f "${df}" ]; then
         if grep -q "multicluster_engine:${freeze_version}" "${df}"; then
-            sed -i "s/multicluster_engine:${freeze_version}/multicluster_engine:${next_version}/g" "${df}"
+            sed -i "s/multicluster_engine:${freeze_version}/multicluster_engine:${current_version}/g" "${df}"
             git add "${df}"
             echo "Updated cpe label in ${df}"
         else
@@ -162,16 +173,15 @@ for df in Dockerfile.j2 Dockerfile.bootstrap-provider Dockerfile.controlplane-pr
     fi
 done
 
-# commit the changes
-
+# Commit
 if [[ "${CI:-}" == "true" ]]; then
-    if git commit -m "Prepare release branch ${next_branch} with updated Tekton YAML, Dockerfiles, sync-branch.yaml and renovate.json"; then
+    if git commit -m "Prepare release branch ${current_branch} with updated Tekton YAML, Dockerfiles, sync-branch.yaml and renovate.json"; then
         echo "Changes committed successfully"
     else
         echo "No changes to commit"
     fi
 else
-    git commit -s -m "create ffwd branch ${next_branch}, freeze ${freeze_branch}"
+    git commit -s -m "create ffwd branches ${current_branch}/${next_branch}, freeze ${freeze_branch}"
 
     read -p "Push changes to ${pr_branch} (y/n)? " -n 1 -r
     echo

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,13 @@
         "lgtm",
         "approved"
     ],
+    "baseBranches": [
+        "master",
+        "backplane-2.9",
+        "backplane-2.10",
+        "backplane-2.11",
+        "backplane-2.17"
+    ],
     "prHourlyLimit": 0,
     "prConcurrentLimit": 0,
     "enabledManagers": [


### PR DESCRIPTION
Switch from single FFWD branch to a two-branch moving window (current + next). Both get fast-forwarded from master on every push. On release cut: freeze current, promote next to current, create new next.

- sync-branch.yaml: FFWD two branches, reset on divergence
- hack/branch: three params (current, next, freeze) with auto-detection from sync-branch.yaml
- release-branch-generator: detect versions from sync-branch.yaml
- renovate.json: add baseBranches to prevent Mintmaker from targeting FFWD branches