### PR TITLE
Fix CAPI_VERSION and CAPM3_VERSION defaults in test README

### DIFF
--- a/test/playbooks/README.md
+++ b/test/playbooks/README.md
@@ -49,8 +49,8 @@ The following environment variables must be set before running the playbook:
 ### Optional Variables (with defaults)
 - `NUMBER_OF_NODES`: Number of available nodes (BMHs) in the test cluster (default: "7")
 - `CLUSTER_TOPOLOGY`: Cluster topology type - "multinode", "sno", "multinode-okd" or "sno-okd" (default: "multinode")
-- `CAPI_VERSION`: Cluster API version to use (default: "v1.9.6")
-- `CAPM3_VERSION`: Cluster API Provider Metal3 version (default: "v1.9.3")  
+- `CAPI_VERSION`: Cluster API version to use (default: "v1.11.3")
+- `CAPM3_VERSION`: Cluster API Provider Metal3 version (default: "v1.11.2")
 - `CONTAINER_TAG`: Container image tag for built images (default: "local")
 
 ### MCE Installation Variables


### PR DESCRIPTION
Update documented defaults to match current values in run_test.yaml (v1.11.3 and v1.11.2 respectively).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated playbook README: revised default optional version values used during installation — CAPI_VERSION now defaults to v1.11.3 (previously v1.9.6) and CAPM3_VERSION now defaults to v1.11.2 (previously v1.9.3). No other instructions or variables changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->