### PR TITLE
NO-ISSUE: Fix auto-merge credentials for bot-opened PRs

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Auto-merge PRs with 'auto-merge' label
         uses: pascalgn/automerge-action@v0.16.4
         env:
-          GITHUB_TOKEN: "${{ secrets.PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "auto-merge" # Only PRs with this label will be considered
           MERGE_METHOD: "squash"
           MERGE_REQUIRED_APPROVALS: 0


### PR DESCRIPTION
Replace secrets.PAT with secrets.GITHUB_TOKEN in the auto-merge workflow. The PAT fails with "Bad credentials" when bots open PRs, while GITHUB_TOKEN is always available and has sufficient permissions (contents: write, pull-requests: write) for the automerge action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated merge workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->