### PR TITLE
Add test: transient API error handling

### DIFF
--- a/internal/tlsconfig/tlsconfig_test.go
+++ b/internal/tlsconfig/tlsconfig_test.go
@@ -23,10 +23,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func newFakeControllerClient(objs ...ctrlclient.Object) ctrlclient.Client {
@@ -153,5 +155,30 @@ var _ = Describe("resolveOpenShiftTLSConfig", func() {
 		_, err := resolveOpenShiftTLSConfig(ctx, k8sClient)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("none of the ciphers from the cluster TLS profile are supported"))
+	})
+})
+
+var _ = Describe("Transient API errors during TLS resolution", func() {
+	It("should propagate a transient API error without retry or fallback", func() {
+		scheme := runtime.NewScheme()
+		_ = configv1.Install(scheme)
+
+		getCalls := 0
+		k8sClient := fakectrlclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ ctrlclient.WithWatch, _ ctrlclient.ObjectKey, _ ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+					getCalls++
+
+					return apierrors.NewServiceUnavailable("transient API error")
+				},
+			}).
+			Build()
+
+		_, err := resolveOpenShiftTLSConfig(context.Background(), k8sClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("fetching TLS adherence policy from APIServer"))
+		Expect(err.Error()).To(ContainSubstring("transient API error"))
+		Expect(getCalls).To(Equal(1), "should call Get exactly once with no retry")
 	})
 })


### PR DESCRIPTION
Add three unit tests for TLS config resolution edge cases:

- NoOpinion ignores configured profile: Verify that resolveOpenShiftTLSConfig uses Intermediate defaults (TLS 1.2) when a Modern profile is explicitly configured on the APIServer CR but tlsAdherence is NoOpinion. Exercises the code path where ShouldHonorClusterTLSProfile returns false despite a restrictive profile being present.
- Transient API error propagation: Verify that a transient API error (ServiceUnavailable) propagates immediately through resolveOpenShiftTLSConfig with no retry or fallback, confirming the current crash-on-transient-error behavior.
- [ACM-34017](https://redhat.atlassian.net/browse/ACM-34017) reproducer (expected failure): Verify that TLSProfileSpec in the result reflects the actual APIServer profile (Modern) when adherence is NoOpinion. This test fails today because resolveOpenShiftTLSConfig stores Intermediate defaults instead of the actual profile. The mismatch causes the SecurityProfileWatcher to detect a spurious profile change on every startup, triggering an infinite restart loop. See [ACM-34017](https://redhat.atlassian.net/browse/ACM-34017).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage simulating transient Kubernetes API errors during TLS resolution to verify the transient error is surfaced and only a single API fetch is attempted (no retry/fallback).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/cluster-api-provider-openshift-assisted/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->