### PR TITLE
MGMT-24454: upgrade to golang 1.26

### DIFF
--- a/Dockerfile.bootstrap-provider
+++ b/Dockerfile.bootstrap-provider
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.controlplane-provider
+++ b/Dockerfile.controlplane-provider
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.distrobox
+++ b/Dockerfile.distrobox
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm
+FROM golang:1.26-bookworm
 RUN curl -sSLO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" &&\
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl &&\
     curl -sSLo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64 &&\

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift-assisted/cluster-api-provider-openshift-assisted
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25 to 1.26 in go.mod and Dockerfiles
- Update toolchain to go1.26.2

https://redhat.atlassian.net/browse/MGMT-24454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go version from 1.25 to 1.26 across build toolchain and project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->