### PR TITLE
Add unit tests for OCP vs vanilla K8s mode edge cases

### DIFF
--- a/internal/openshift/openshift_test.go
+++ b/internal/openshift/openshift_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/openapi"
+)
+
+type fakeDiscovery struct {
+	serverResourcesFn func(groupVersion string) (*metav1.APIResourceList, error)
+}
+
+func (f *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	return f.serverResourcesFn(groupVersion)
+}
+
+func (f *fakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, nil
+}
+
+func (f *fakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (f *fakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (f *fakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return nil, nil
+}
+
+func (f *fakeDiscovery) ServerVersion() (*version.Info, error) {
+	return nil, nil
+}
+
+func (f *fakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	return nil, nil
+}
+
+func (f *fakeDiscovery) OpenAPIV3() openapi.Client {
+	return nil
+}
+
+func (f *fakeDiscovery) RESTClient() restclient.Interface {
+	return nil
+}
+
+func (f *fakeDiscovery) WithLegacy() discovery.DiscoveryInterface {
+	return f
+}
+
+var _ discovery.DiscoveryInterface = &fakeDiscovery{}
+
+var _ = Describe("isOpenShiftWithDiscovery", func() {
+	It("should detect OpenShift when apiservers resource exists", func() {
+		disc := &fakeDiscovery{
+			serverResourcesFn: func(_ string) (*metav1.APIResourceList, error) {
+				return &metav1.APIResourceList{
+					APIResources: []metav1.APIResource{
+						{Name: "apiservers"},
+					},
+				}, nil
+			},
+		}
+
+		result, err := isOpenShiftWithDiscovery(context.Background(), disc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("should detect vanilla K8s when API group does not exist", func() {
+		disc := &fakeDiscovery{
+			serverResourcesFn: func(_ string) (*metav1.APIResourceList, error) {
+				return nil, apierrors.NewNotFound(
+					schema.GroupResource{Group: "config.openshift.io", Resource: "apiservers"}, "")
+			},
+		}
+
+		result, err := isOpenShiftWithDiscovery(context.Background(), disc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("should detect vanilla K8s when API group exists but apiservers resource is missing", func() {
+		disc := &fakeDiscovery{
+			serverResourcesFn: func(_ string) (*metav1.APIResourceList, error) {
+				return &metav1.APIResourceList{
+					APIResources: []metav1.APIResource{
+						{Name: "infrastructures"},
+						{Name: "ingresses"},
+					},
+				}, nil
+			},
+		}
+
+		result, err := isOpenShiftWithDiscovery(context.Background(), disc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("should retry on transient API error then succeed", func() {
+		var calls int32
+		disc := &fakeDiscovery{
+			serverResourcesFn: func(_ string) (*metav1.APIResourceList, error) {
+				call := atomic.AddInt32(&calls, 1)
+				if call == 1 {
+					return nil, fmt.Errorf("connection refused")
+				}
+
+				return &metav1.APIResourceList{
+					APIResources: []metav1.APIResource{
+						{Name: "apiservers"},
+					},
+				}, nil
+			},
+		}
+
+		result, err := isOpenShiftWithDiscovery(context.Background(), disc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeTrue())
+		Expect(atomic.LoadInt32(&calls)).To(BeNumerically("==", 2))
+	})
+
+	It("should return error when context is cancelled during retry", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		disc := &fakeDiscovery{
+			serverResourcesFn: func(_ string) (*metav1.APIResourceList, error) {
+				cancel()
+
+				return nil, fmt.Errorf("connection refused")
+			},
+		}
+
+		result, err := isOpenShiftWithDiscovery(ctx, disc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("waiting for API server"))
+		Expect(result).To(BeFalse())
+	})
+
+	It("should return false when resource list is empty", func() {
+		disc := &fakeDiscovery{
+			serverResourcesFn: func(_ string) (*metav1.APIResourceList, error) {
+				return &metav1.APIResourceList{
+					APIResources: []metav1.APIResource{},
+				}, nil
+			},
+		}
+
+		result, err := isOpenShiftWithDiscovery(context.Background(), disc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+})

--- a/internal/openshift/suite_test.go
+++ b/internal/openshift/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOpenShift(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OpenShift Suite")
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -18,6 +18,7 @@ package setup
 
 import (
 	"context"
+	"crypto/tls"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -140,3 +141,28 @@ var _ = Describe("SetupSecurityProfileWatcher OnProfileChange callback behavior"
 		})
 	})
 })
+
+var _ = Describe("ResolveTLSConfig", func() {
+	It("should return Intermediate defaults when isOpenShift is false", func() {
+		result, err := ResolveTLSConfig(context.Background(), nil, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.TLSConfig).NotTo(BeNil())
+		Expect(result.TLSAdherencePolicy).To(Equal(configv1.TLSAdherencePolicy("")))
+
+		cfg := &tls.Config{}
+		result.TLSConfig(cfg)
+		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+	})
+})
+
+var _ = Describe("SetupSecurityProfileWatcher", func() {
+	It("should be a no-op when isOpenShift is false", func() {
+		called := false
+		cancel := func() { called = true }
+
+		err := SetupSecurityProfileWatcher(nil, tlsconfig.TLSConfigResult{}, false, cancel)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(called).To(BeFalse())
+	})
+})
+


### PR DESCRIPTION
Test IsOpenShift detection logic: OCP happy path, vanilla K8s (NotFound), partial CRD registration, transient error retry, context cancellation during retry, and empty resource list.

Test setup k8s-mode paths: ResolveTLSConfig returns Intermediate defaults when isOpenShift=false, SetupSecurityProfileWatcher is a no-op when isOpenShift=false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added coverage for OpenShift environment detection, including presence/absence cases, transient retry behavior, and context-cancellation error handling.
  * Expanded TLS configuration tests to validate default TLS settings when not running on OpenShift.
  * Extended security profile watcher tests to verify no-op behavior when not on OpenShift and correct callback/cancellation behavior across policy transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->