### PR TITLE
MNO disable baremetal capability

### DIFF
--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	defaultBaremetalAdditionalCapabilities = []configv1.ClusterVersionCapability{"baremetal", "Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig"}
+	defaultBaremetalAdditionalCapabilities = []configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig"}
 )
 
 // ClusterDeploymentReconciler reconciles a ClusterDeployment object

--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	defaultBaremetalAdditionalCapabilities = []configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig"}
+	defaultBaremetalAdditionalCapabilities = []configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning"}
 )
 
 // ClusterDeploymentReconciler reconciles a ClusterDeployment object

--- a/controlplane/internal/controller/clusterdeployment_controller_test.go
+++ b/controlplane/internal/controller/clusterdeployment_controller_test.go
@@ -296,7 +296,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cd), aci)).To(Succeed())
 					By("Verifying the ACI has the default install config overrides for baremetal set in its annotations")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
 				})
 			})
 			When("additional capabilities are specified", func() {
@@ -313,11 +313,11 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal and the additional capability set in its annotations")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
 				})
 			})
-			When("additional capabilities are the same as the default baremetal capabilities", func() {
-				It("ACI should have default baremetal install config override annotation with no duplicates", func() {
+			When("additional capabilities include baremetal explicitly", func() {
+				It("ACI should have default baremetal install config override annotation with baremetal appended", func() {
 					oacp.Spec.Config.Capabilities = controlplanev1alpha3.Capabilities{AdditionalEnabledCapabilities: []string{"baremetal"}}
 					Expect(k8sClient.Update(ctx, oacp)).To(Succeed())
 
@@ -329,9 +329,9 @@ var _ = Describe("ClusterDeployment Controller", func() {
 					aci := &hiveext.AgentClusterInstall{}
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cd), aci)).To(Succeed())
 
-					By("Verifying the ACI has the default install config overrides for baremetal without duplicates")
+					By("Verifying the ACI has the default install config overrides for baremetal with baremetal appended")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","baremetal"]}}`))
 				})
 			})
 			When("additional capabilities include MAPI", func() {
@@ -349,7 +349,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal without MAPI")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
 				})
 			})
 			When("only baseline capability is specified", func() {
@@ -367,7 +367,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the correct install config overrides for baremetal and the specified baseline capability")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"vCurrent","additionalEnabledCapabilities":["baremetal","Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"vCurrent","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
 				})
 			})
 			When("install config override annotation is set with MAPI capability", func() {
@@ -401,7 +401,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 					cfgOverride := controller.InstallConfigOverride{}
 					Expect(json.Unmarshal([]byte(aci.Annotations[controller.InstallConfigOverrides]), &cfgOverride)).NotTo(HaveOccurred())
 
-					Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"baremetal", "Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig", "CloudControllerManager"}))
+					Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig", "CloudControllerManager"}))
 					Expect(cfgOverride.Capability.BaselineCapabilitySet).To(Equal(configv1.ClusterVersionCapabilitySet("None")))
 
 					// Verify MAPI is not in the capabilities

--- a/controlplane/internal/controller/clusterdeployment_controller_test.go
+++ b/controlplane/internal/controller/clusterdeployment_controller_test.go
@@ -240,7 +240,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 				cfgOverride := controller.InstallConfigOverride{}
 				Expect(json.Unmarshal([]byte(aci.Annotations[controller.InstallConfigOverrides]), &cfgOverride)).NotTo(HaveOccurred())
-				Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"baremetal", "Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig"}))
+				Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig"}))
 				Expect(cfgOverride.Capability.BaselineCapabilitySet).To(Equal(configv1.ClusterVersionCapabilitySet("None")))
 
 			})

--- a/controlplane/internal/controller/clusterdeployment_controller_test.go
+++ b/controlplane/internal/controller/clusterdeployment_controller_test.go
@@ -240,7 +240,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 				cfgOverride := controller.InstallConfigOverride{}
 				Expect(json.Unmarshal([]byte(aci.Annotations[controller.InstallConfigOverrides]), &cfgOverride)).NotTo(HaveOccurred())
-				Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig"}))
+				Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning"}))
 				Expect(cfgOverride.Capability.BaselineCapabilitySet).To(Equal(configv1.ClusterVersionCapabilitySet("None")))
 
 			})
@@ -296,7 +296,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cd), aci)).To(Succeed())
 					By("Verifying the ACI has the default install config overrides for baremetal set in its annotations")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning"]}}`))
 				})
 			})
 			When("additional capabilities are specified", func() {
@@ -313,7 +313,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal and the additional capability set in its annotations")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","CloudControllerManager"]}}`))
 				})
 			})
 			When("additional capabilities include baremetal explicitly", func() {
@@ -331,7 +331,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal with baremetal appended")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","baremetal"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","baremetal"]}}`))
 				})
 			})
 			When("additional capabilities include MAPI", func() {
@@ -349,7 +349,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the default install config overrides for baremetal without MAPI")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig","CloudControllerManager"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"None","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","CloudControllerManager"]}}`))
 				})
 			})
 			When("only baseline capability is specified", func() {
@@ -367,7 +367,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 
 					By("Verifying the ACI has the correct install config overrides for baremetal and the specified baseline capability")
 					Expect(aci.Annotations).To(HaveKey(controller.InstallConfigOverrides))
-					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"vCurrent","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning","DeploymentConfig"]}}`))
+					Expect(aci.Annotations[controller.InstallConfigOverrides]).To(Equal(`{"capabilities":{"baselineCapabilitySet":"vCurrent","additionalEnabledCapabilities":["Console","Insights","OperatorLifecycleManager","Ingress","marketplace","NodeTuning"]}}`))
 				})
 			})
 			When("install config override annotation is set with MAPI capability", func() {
@@ -401,7 +401,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 					cfgOverride := controller.InstallConfigOverride{}
 					Expect(json.Unmarshal([]byte(aci.Annotations[controller.InstallConfigOverrides]), &cfgOverride)).NotTo(HaveOccurred())
 
-					Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "DeploymentConfig", "CloudControllerManager"}))
+					Expect(cfgOverride.Capability.AdditionalEnabledCapabilities).To(Equal([]configv1.ClusterVersionCapability{"Console", "Insights", "OperatorLifecycleManager", "Ingress", "marketplace", "NodeTuning", "CloudControllerManager"}))
 					Expect(cfgOverride.Capability.BaselineCapabilitySet).To(Equal(configv1.ClusterVersionCapabilitySet("None")))
 
 					// Verify MAPI is not in the capabilities


### PR DESCRIPTION
PR aims to remove CBO from being enabled by default on MNO clusters.
CAPOA with external provisioning uses management cluster's Assisted Installer + Metal3/Ironic handles bare metal provisioning. The deployed cluster should never need its own Ironic. 
Including `baremetal` in the defaults causes the workload cluster's baremetal CO to try deploying a local Ironic.

- `clusterdeployment_controller.go` — remove "baremetal" from the `defaultBaremetalAdditionalCapabilities`
- `clusterdeployment_controller_test.go` — there's an assertion that checks capabilities. Updated the expected capabilities list to no longer include "baremetal"

Users can still opt back in by explicitly adding "baremetal" to `spec.config.capabilities.additionalEnabledCapabilities`
Additionally, CBO depends on the Machine API (MAPI) for bare metal lifecycle management, but CAPOA-provisioned clusters use Cluster API (CAPI). CBO has no functional role in a CAPI-managed cluster.

CC: @rccrdpccl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default set of enabled capabilities for baremetal installations so the baremetal capability is no longer included automatically.
  * Adjusted expected installation settings to match the new default capability list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->