### PR TITLE
ACM-31156: Test and validate network policies for CAPOA components

### DIFF
--- a/bootstrap-components.yaml
+++ b/bootstrap-components.yaml
@@ -1515,6 +1515,70 @@ metadata:
 spec:
   selfSigned: {}
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: capoa-bootstrap-controller-manager
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-bootstrap-system
+spec:
+  egress:
+  - ports:
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: apiserver
+  - ports:
+    - port: 8090
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32
+    - ipBlock:
+        cidr: ::/0
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - port: 8080
+      protocol: TCP
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: capoa-bootstrap-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/bootstrap/config/manager/capoa-bootstrap-networkpolicy.yaml
+++ b/bootstrap/config/manager/capoa-bootstrap-networkpolicy.yaml
@@ -1,0 +1,70 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-bootstrap-system
+  labels:
+    control-plane: capoa-bootstrap-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: capoa-bootstrap-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic
+    - from:
+        - podSelector: {}
+    # Monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Webhook calls from kube-apiserver (validating + conversion)
+    - ports:
+        - protocol: TCP
+          port: 9443
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              component: apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+    # assisted-service (ignition download, port varies by deployment)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 8090
+    # HTTPS egress (assisted-service external mode)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/bootstrap/config/manager/kustomization.yaml
+++ b/bootstrap/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- capoa-bootstrap-networkpolicy.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/controlplane-components.yaml
+++ b/controlplane-components.yaml
@@ -1707,3 +1707,59 @@ metadata:
   namespace: capoa-controlplane-system
 spec:
   selfSigned: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: capoa-controlplane-controller-manager
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-controlplane-system
+spec:
+  egress:
+  - ports:
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32
+    - ipBlock:
+        cidr: ::/0
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - port: 8080
+      protocol: TCP
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: capoa-controlplane-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress

--- a/controlplane/config/manager/capoa-controlplane-networkpolicy.yaml
+++ b/controlplane/config/manager/capoa-controlplane-networkpolicy.yaml
@@ -1,0 +1,61 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-controlplane-system
+  labels:
+    control-plane: capoa-controlplane-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: capoa-controlplane-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic
+    - from:
+        - podSelector: {}
+    # Monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Webhook calls from kube-apiserver (conversion)
+    - ports:
+        - protocol: TCP
+          port: 9443
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API and spoke/workload cluster API servers (dynamic IPs)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 6443
+    # HTTPS egress (container registries for release image manifests)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/controlplane/config/manager/kustomization.yaml
+++ b/controlplane/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- capoa-controlplane-networkpolicy.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/test/e2e/manifests/capboa/bootstrap_install.yaml
+++ b/test/e2e/manifests/capboa/bootstrap_install.yaml
@@ -1515,6 +1515,70 @@ metadata:
 spec:
   selfSigned: {}
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: capoa-bootstrap-controller-manager
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-bootstrap-system
+spec:
+  egress:
+  - ports:
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: apiserver
+  - ports:
+    - port: 8090
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32
+    - ipBlock:
+        cidr: ::/0
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - port: 8080
+      protocol: TCP
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: capoa-bootstrap-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/test/e2e/manifests/capcoa/controlplane_install.yaml
+++ b/test/e2e/manifests/capcoa/controlplane_install.yaml
@@ -1707,3 +1707,59 @@ metadata:
   namespace: capoa-controlplane-system
 spec:
   selfSigned: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: capoa-controlplane-controller-manager
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-controlplane-system
+spec:
+  egress:
+  - ports:
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32
+    - ipBlock:
+        cidr: ::/0
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - port: 8080
+      protocol: TCP
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: capoa-controlplane-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
## Summary

Adds per-component NetworkPolicies for both CAPOA providers:

- **Bootstrap provider** (`capoa-bootstrap-system`) — ingress on 8080 (metrics), 9443 (webhooks); egress to DNS, K8s API, assisted-service (8090), HTTPS
- **Controlplane provider** (`capoa-controlplane-system`) — ingress on 8080 (metrics), 9443 (webhooks); egress to DNS, K8s API, spoke cluster APIs (6443), container registries (443)

## Test results (kind + Calico)

```
=== SUMMARY: 12 passed, 0 failed ===
```

## Related

- Jira: [ACM-31156](https://redhat.atlassian.net/browse/ACM-31156)
- Also resolves: [ACM-37738](https://redhat.atlassian.net/browse/ACM-37738)
- Epic: [ACM-31152](https://redhat.atlassian.net/browse/ACM-31152)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes network security policies for both the bootstrap and control plane controller managers.
  * Restricted inbound and outbound traffic to required endpoints, including monitoring access, DNS resolution, Kubernetes API connectivity, and HTTPS/assisted-service traffic (with safeguards for link-local metadata).
  * Enabled these policies via the existing controller manager manifests and Kustomize configuration so the restrictions are applied automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->