### PR TITLE
NO-ISSUE: Add OCP e2e test playbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ e2e-test-dependencies:
 e2e-test: e2e-test-dependencies
 	ansible-playbook $(PLAYBOOK_DIR)/run_test.yaml -i $(PLAYBOOK_DIR)/inventories/remote_host.yaml
 
+.PHONY: e2e-test-ocp
+e2e-test-ocp: e2e-test-dependencies
+	ansible-playbook $(PLAYBOOK_DIR)/run_test_ocp.yaml -i $(PLAYBOOK_DIR)/inventories/ocp_host.yaml
+
 .PHONY: versions-management-dependencies
 versions-management-dependencies:
 	pip install -r hack/versions-management/requirements.txt

--- a/test/e2e/libvirt/network-bmh.xml.j2
+++ b/test/e2e/libvirt/network-bmh.xml.j2
@@ -34,8 +34,12 @@
     <dnsmasq:option value='address=/api-int.test-{{ cluster_topology }}.lab.home/192.168.222.40'/>
     <dnsmasq:option value='address=/.apps.test-{{ cluster_topology }}.lab.home/192.168.222.41'/>
 {% endif %}
+{% if management_cluster_type | default('kind') == 'ocp' %}
+    <dnsmasq:option value='address=/.{{ ocp_apps_domain }}/{{ loadbalancer_ip }}'/>
+{% else %}
     <dnsmasq:option value='address=/assisted-service.assisted-installer.com/{{ loadbalancer_ip }}'/>
     <dnsmasq:option value='address=/assisted-image.assisted-installer.com/{{ loadbalancer_ip }}'/>
+{% endif %}
 {% for dns in host_dns_servers %}
     <dnsmasq:option value='server={{ dns }}'/>
 {% endfor %}

--- a/test/playbooks/README.md
+++ b/test/playbooks/README.md
@@ -2,6 +2,13 @@
 
 This directory contains Ansible playbooks for running end-to-end tests of the Cluster API Provider OpenShift Assisted project.
 
+Two test flows are available:
+
+| Flow | Playbook | Management Cluster | MCE Installation |
+|------|----------|-------------------|-----------------|
+| **Kind** | `run_test.yaml` | Kind cluster (created by playbook) | Helm chart or clusterctl |
+| **OCP** | `run_test_ocp.yaml` | Pre-existing OCP cluster | OLM (production or nightly catalog) |
+
 ## Main Playbook: run_test.yaml
 
 The `run_test.yaml` playbook is the primary test automation script that sets up a complete testing environment and runs comprehensive end-to-end tests for the Cluster API Provider OpenShift Assisted.
@@ -345,3 +352,157 @@ USE_MCE_CHART=true INSTALLATION_MODE=upstream \
   MCE_CAPOA_BOOTSTRAP_IMAGE=quay.io/myrepo/capoa-bootstrap:dev \
   make e2e-test
 ```
+
+## OCP Flow: run_test_ocp.yaml
+
+The OCP flow is a full e2e test that starts from a bare host and:
+1. Deploys an OCP management cluster via [dev-scripts](https://github.com/openshift-metal3/dev-scripts)
+2. Installs MCE via OLM on the OCP cluster
+3. Sets up emulated bare-metal nodes (libvirt VMs + sushy-tools)
+4. Provisions a workload cluster using CAPOA
+
+This exercises the production delivery path (OCP + MCE via OLM) rather than the Kind-based development path.
+
+### Prerequisites
+
+- SSH access to a remote bare-metal host with sufficient resources for both the OCP management cluster (dev-scripts VMs) and the emulated workload cluster nodes (libvirt VMs)
+- Pull secret for container registries (base64-encoded)
+- If using a custom MCE catalog image from `quay.io/acm-d`, the pull secret must include credentials for that registry
+
+### Quick Start
+
+```bash
+# Full e2e: deploy OCP (compact), install MCE, provision workload cluster
+make e2e-test-ocp
+
+# Use a specific OCP release image
+OCP_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.20.0-x86_64 \
+  make e2e-test-ocp
+
+# Test with a nightly MCE build
+MCE_CATALOG_IMAGE=quay.io/acm-d/mce-custom-registry:2.11-BACKPLANE-2025-07-15-00-26-11 \
+  make e2e-test-ocp
+```
+
+### Required Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `REMOTE_HOST` | Hostname/IP of the remote bare-metal host |
+| `SSH_KEY_FILE` | Path to SSH private key for the remote host |
+| `SSH_AUTHORIZED_KEY` | SSH public key content |
+| `PULLSECRET` | Base64-encoded container registry pull secret |
+
+### OCP Management Cluster Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OCP_TOPOLOGY` | `compact` | OCP management cluster topology preset (see below) |
+| `OCP_VERSION` | `4.20` | OCP release stream for dev-scripts |
+| `OCP_RELEASE_IMAGE` | (empty) | Specific OCP release image (overrides `OCP_VERSION`) |
+| `SKIP_OCP_INSTALL` | `false` | Skip OCP deployment, use existing cluster |
+| `OCP_KUBECONFIG_PATH` | (empty) | Kubeconfig for existing cluster (required when `SKIP_OCP_INSTALL=true`) |
+| `OCP_CLUSTER_DOMAIN` | (auto-discovered) | OCP apps domain |
+| `OCP_ROUTER_IP` | (auto-discovered) | OCP router IP address |
+
+#### OCP Topology Presets
+
+| Preset | Masters | Workers | Master RAM | Master vCPUs | Master Disk |
+|--------|---------|---------|------------|--------------|-------------|
+| `compact` | 3 | 0 | 32 GB | 16 | 100 GB |
+| `ha` | 3 | 2 | 32 GB | 16 | 100 GB |
+| `sno` | 1 | 0 | 64 GB | 16 | 120 GB |
+
+### MCE OLM Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCE_CATALOG_IMAGE` | (empty = `redhat-operators`) | Custom catalog index image |
+| `MCE_CHANNEL` | `stable-2.11` | OLM subscription channel |
+| `MCE_NAMESPACE` | `multicluster-engine` | Namespace for MCE installation |
+| `MCE_CREATE_IDMS` | auto | Create ImageDigestMirrorSet (`true`/`false`; auto = yes when custom catalog) |
+| `SKIP_MCE_INSTALL` | `false` | Skip MCE installation (assume pre-installed) |
+
+### Workload Cluster Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLUSTER_TOPOLOGY` | `multinode` | `multinode`, `sno`, `multinode-okd`, or `sno-okd` |
+| `NUMBER_OF_NODES` | `7` | Number of emulated BMH nodes |
+| `SKIP_CLUSTER` | `false` | Skip cluster provisioning and assertions |
+
+### MCE Catalog Modes
+
+#### Production Mode (default)
+
+Uses the `redhat-operators` CatalogSource that ships with OCP. No additional configuration needed.
+
+```bash
+make e2e-test-ocp
+```
+
+#### Custom Catalog Mode
+
+Set `MCE_CATALOG_IMAGE` to a custom catalog index image. This creates a custom `CatalogSource` and (by default) an `ImageDigestMirrorSet` to mirror `registry.redhat.io/multicluster-engine` to `quay.io/acm-d`.
+
+```bash
+# Specific nightly snapshot
+MCE_CATALOG_IMAGE=quay.io/acm-d/mce-custom-registry:2.11-BACKPLANE-2025-07-15-00-26-11 \
+  make e2e-test-ocp
+
+# Disable IDMS creation (e.g. if already configured)
+MCE_CATALOG_IMAGE=quay.io/acm-d/mce-custom-registry:2.11-BACKPLANE-2025-07-15-00-26-11 \
+  MCE_CREATE_IDMS=false make e2e-test-ocp
+```
+
+### Operational Modes
+
+```bash
+# Full e2e (default)
+make e2e-test-ocp
+
+# Skip OCP deploy, use existing cluster
+SKIP_OCP_INSTALL=true OCP_KUBECONFIG_PATH=~/.kube/ocp-config make e2e-test-ocp
+
+# Skip OCP + MCE install, just provision workload cluster
+SKIP_OCP_INSTALL=true OCP_KUBECONFIG_PATH=~/.kube/ocp-config \
+  SKIP_MCE_INSTALL=true make e2e-test-ocp
+
+# Demo mode: setup infra + BMHs only
+SKIP_MCE_INSTALL=true SKIP_CLUSTER=true make e2e-test-ocp
+```
+
+### OCP Flow Roles
+
+| # | Role | Description |
+|---|------|-------------|
+| 1 | `system_dependencies` | Install OS packages (shared with Kind flow) |
+| 2 | `sourcecode_setup` | Sync source code to remote host (shared) |
+| 3 | `network_setup` | Configure libvirt network and DNS (shared) |
+| 4 | `baremetal_emulation` | Start sushy-tools BMC emulator (shared) |
+| 5 | `dev_scripts_setup` | Deploy OCP management cluster via dev-scripts |
+| 6 | `ocp_cluster_setup` | Validate OCP cluster, discover apps domain and router IP |
+| 7 | `mce_olm_install` | Install MCE via OLM, create MCE CR and AgentServiceConfig |
+| 8 | `bmh_setup` | Create libvirt VMs and BareMetalHost CRs (shared) |
+| 9 | `cluster_install` | Apply cluster example manifests (shared) |
+| 10 | `assert_install` | Validate cluster installation (shared) |
+| 11 | `assert_upgrade` | Validate cluster upgrade (shared, conditional) |
+
+### Network Layout
+
+The OCP flow creates two independent libvirt networks on the same host:
+
+| Network | Subnet | Purpose | Created By |
+|---------|--------|---------|------------|
+| dev-scripts networks | `192.168.111.0/24`, `192.168.126.0/24` | OCP management cluster VMs | dev-scripts |
+| `bmh` | `192.168.222.0/24` | Workload cluster emulated BMH VMs | network_setup / bmh_setup |
+
+These subnets do not overlap. The `bmh` network's dnsmasq is configured to resolve `*.apps.<ocp-domain>` to the OCP router IP so that emulated VMs can reach the assisted-service and assisted-image-service Routes.
+
+### Cleanup
+
+```bash
+ansible-playbook test/playbooks/cleanup_ocp.yaml -i test/playbooks/inventories/ocp_host.yaml
+```
+
+This removes: test namespace, MCE (CR, Subscription, CSV, namespace), custom CatalogSource, IDMS, libvirt VMs, bmh network, and the dev-scripts OCP cluster.

--- a/test/playbooks/cleanup_ocp.yaml
+++ b/test/playbooks/cleanup_ocp.yaml
@@ -1,0 +1,18 @@
+---
+- name: Cleanup OCP e2e test
+  hosts: test_runner
+  vars:
+    src_dir: "/tmp/capbcoa"
+    test_namespace: test-capi
+    mce_namespace: "{{ lookup('ansible.builtin.env', 'MCE_NAMESPACE', default='multicluster-engine') }}"
+    number_of_nodes: "{{ lookup('ansible.builtin.env', 'NUMBER_OF_NODES', default='7') }}"
+    dev_scripts_dir: /home/dev-scripts
+    skip_ocp_install: "{{ lookup('ansible.builtin.env', 'SKIP_OCP_INSTALL', default='false') | lower in ['true', '1', 'yes'] }}"
+    skip_mce_install: "{{ lookup('ansible.builtin.env', 'SKIP_MCE_INSTALL', default='false') | lower in ['true', '1', 'yes'] }}"
+    extra_paths:
+      - /usr/local/bin
+  environment:
+    PATH: "{{ extra_paths | join(':') }}:{{ ansible_env.PATH }}"
+    KUBECONFIG: /tmp/ocp-kubeconfig
+  roles:
+    - cleanup_ocp

--- a/test/playbooks/inventories/ocp_host.yaml
+++ b/test/playbooks/inventories/ocp_host.yaml
@@ -1,0 +1,8 @@
+---
+baremetal:
+  hosts:
+    test_runner:
+      ansible_host: "{{ lookup('ansible.builtin.env', 'REMOTE_HOST') }}"
+      ansible_user: root
+      ansible_ssh_private_key_file: "{{ lookup('ansible.builtin.env', 'SSH_KEY_FILE') }}"
+      ansible_ssh_common_args: "-A -o StrictHostKeyChecking=no -o 'UserKnownHostsFile=/dev/null'"

--- a/test/playbooks/roles/cleanup_ocp/tasks/main.yaml
+++ b/test/playbooks/roles/cleanup_ocp/tasks/main.yaml
@@ -1,0 +1,118 @@
+---
+- name: Delete sushytools pod
+  containers.podman.podman_container:
+    name: sushy-tools
+    state: absent
+
+- name: Delete test namespace
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Namespace
+    name: "{{ test_namespace }}"
+    state: absent
+    wait: true
+    wait_timeout: 300
+  failed_when: false
+
+- name: Delete AgentServiceConfig
+  kubernetes.core.k8s:
+    api_version: agent-install.openshift.io/v1beta1
+    kind: AgentServiceConfig
+    name: agent
+    state: absent
+    wait: true
+    wait_timeout: 300
+  failed_when: false
+  when: not skip_mce_install
+
+- name: Delete MultiClusterEngine CR
+  kubernetes.core.k8s:
+    api_version: multicluster.openshift.io/v1
+    kind: MultiClusterEngine
+    name: multiclusterengine
+    state: absent
+    wait: true
+    wait_timeout: 600
+  failed_when: false
+  when: not skip_mce_install
+
+- name: Delete MCE Subscription
+  kubernetes.core.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: multicluster-engine
+    namespace: "{{ mce_namespace }}"
+    state: absent
+  failed_when: false
+  when: not skip_mce_install
+
+- name: Delete MCE CSVs
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - delete
+      - csv
+      - -n
+      - "{{ mce_namespace }}"
+      - --all
+  failed_when: false
+  changed_when: true
+  when: not skip_mce_install
+
+- name: Delete MCE namespace
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Namespace
+    name: "{{ mce_namespace }}"
+    state: absent
+    wait: true
+    wait_timeout: 300
+  failed_when: false
+  when: not skip_mce_install
+
+- name: Delete custom CatalogSource
+  kubernetes.core.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: mce-custom-catalog
+    namespace: openshift-marketplace
+    state: absent
+  failed_when: false
+  when: not skip_mce_install
+
+- name: Delete ImageDigestMirrorSet
+  kubernetes.core.k8s:
+    api_version: config.openshift.io/v1
+    kind: ImageDigestMirrorSet
+    name: mce-downstream-mirror
+    state: absent
+  failed_when: false
+  when: not skip_mce_install
+
+- name: Destroy VMs
+  community.libvirt.virt:
+    name: "bmh-vm-{{ item }}"
+    state: destroyed
+  with_sequence:
+    count: "{{ number_of_nodes }}"
+    format: "%02x"
+  failed_when: false
+
+- name: Remove bmh network
+  community.libvirt.virt_net:
+    state: absent
+    name: bmh
+
+- name: Check if dev-scripts directory exists
+  ansible.builtin.stat:
+    path: "{{ dev_scripts_dir }}"
+  register: dev_scripts_stat
+  when: not skip_ocp_install
+
+- name: Tear down dev-scripts OCP cluster
+  ansible.builtin.command:
+    cmd: make clean
+    chdir: "{{ dev_scripts_dir }}"
+  when: not skip_ocp_install and dev_scripts_stat.stat.exists | default(false)
+  changed_when: true
+  failed_when: false

--- a/test/playbooks/roles/dev_scripts_setup/defaults/main.yaml
+++ b/test/playbooks/roles/dev_scripts_setup/defaults/main.yaml
@@ -1,0 +1,32 @@
+---
+dev_scripts_repo: "https://github.com/openshift-metal3/dev-scripts.git"
+dev_scripts_branch: "master"
+dev_scripts_dir: "/home/dev-scripts"
+dev_scripts_ocp_version: "4.20"
+dev_scripts_release_image: ""
+dev_scripts_cluster_name: "ostest"
+
+dev_scripts_topology: "compact"
+
+dev_scripts_topologies:
+  compact:
+    num_masters: 3
+    num_workers: 0
+    master_memory: 32768
+    master_disk: 100
+    master_vcpu: 16
+  ha:
+    num_masters: 3
+    num_workers: 2
+    master_memory: 32768
+    master_disk: 100
+    master_vcpu: 16
+    worker_memory: 16384
+    worker_disk: 100
+    worker_vcpu: 8
+  sno:
+    num_masters: 1
+    num_workers: 0
+    master_memory: 65536
+    master_disk: 120
+    master_vcpu: 16

--- a/test/playbooks/roles/dev_scripts_setup/tasks/main.yaml
+++ b/test/playbooks/roles/dev_scripts_setup/tasks/main.yaml
@@ -1,0 +1,70 @@
+---
+- name: Install dev-scripts dependencies
+  ansible.builtin.dnf:
+    name:
+      - git
+      - make
+    state: present
+
+- name: Clone dev-scripts
+  ansible.builtin.git:
+    repo: "{{ dev_scripts_repo }}"
+    dest: "{{ dev_scripts_dir }}"
+    version: "{{ dev_scripts_branch }}"
+    force: true
+
+- name: Write pull secret file
+  ansible.builtin.copy:
+    content: "{{ pullsecret | b64decode }}"
+    dest: "{{ dev_scripts_dir }}/pull_secret.json"
+    mode: '0600'
+
+- name: Generate dev-scripts config
+  ansible.builtin.template:
+    src: config.sh.j2
+    dest: "{{ dev_scripts_dir }}/config_{{ ansible_user }}.sh"
+    mode: '0755'
+
+- name: Display dev-scripts configuration
+  ansible.builtin.debug:
+    msg: >-
+      Deploying OCP {{ dev_scripts_ocp_version }} via dev-scripts
+      (topology: {{ dev_scripts_topology }},
+      masters: {{ dev_scripts_topologies[dev_scripts_topology].num_masters }},
+      workers: {{ dev_scripts_topologies[dev_scripts_topology].num_workers }})
+
+- name: Run dev-scripts
+  ansible.builtin.command:
+    cmd: make
+    chdir: "{{ dev_scripts_dir }}"
+  changed_when: true
+  timeout: 7200
+
+- name: Locate kubeconfig
+  ansible.builtin.stat:
+    path: "{{ dev_scripts_dir }}/ocp/{{ dev_scripts_cluster_name }}/auth/kubeconfig"
+  register: kubeconfig_stat
+
+- name: Fail if kubeconfig not found
+  ansible.builtin.fail:
+    msg: >-
+      dev-scripts kubeconfig not found at
+      {{ dev_scripts_dir }}/ocp/{{ dev_scripts_cluster_name }}/auth/kubeconfig
+  when: not kubeconfig_stat.stat.exists
+
+- name: Copy kubeconfig to standard location
+  ansible.builtin.copy:
+    src: "{{ dev_scripts_dir }}/ocp/{{ dev_scripts_cluster_name }}/auth/kubeconfig"
+    dest: /tmp/ocp-kubeconfig
+    mode: '0600'
+    remote_src: true
+
+- name: Validate OCP cluster is ready
+  ansible.builtin.command: kubectl get clusterversion
+  environment:
+    KUBECONFIG: /tmp/ocp-kubeconfig
+  register: cv_result
+  changed_when: false
+  retries: "{{ medium_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+  until: cv_result.rc == 0

--- a/test/playbooks/roles/dev_scripts_setup/templates/config.sh.j2
+++ b/test/playbooks/roles/dev_scripts_setup/templates/config.sh.j2
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o nounset
+
+export IP_STACK="v4"
+export NETWORK_TYPE="OVNKubernetes"
+export PROVISIONING_NETWORK_PROFILE="Disabled"
+export CLUSTER_NAME="{{ dev_scripts_cluster_name }}"
+
+{% set topo = dev_scripts_topologies[dev_scripts_topology] %}
+export NUM_MASTERS={{ topo.num_masters }}
+export NUM_WORKERS={{ topo.num_workers }}
+export MASTER_MEMORY={{ topo.master_memory }}
+export MASTER_DISK={{ topo.master_disk }}
+export MASTER_VCPU={{ topo.master_vcpu }}
+{% if topo.num_workers > 0 %}
+export WORKER_MEMORY={{ topo.worker_memory }}
+export WORKER_DISK={{ topo.worker_disk }}
+export WORKER_VCPU={{ topo.worker_vcpu }}
+{% endif %}
+
+{% if dev_scripts_release_image != '' %}
+export OPENSHIFT_RELEASE_IMAGE="{{ dev_scripts_release_image }}"
+{% else %}
+export OPENSHIFT_RELEASE_STREAM="{{ dev_scripts_ocp_version }}"
+export OPENSHIFT_RELEASE_TYPE="nightly"
+{% endif %}

--- a/test/playbooks/roles/mce_olm_install/defaults/main.yaml
+++ b/test/playbooks/roles/mce_olm_install/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+mce_catalog_image: ""
+mce_channel: "stable-2.11"
+mce_package_name: "multicluster-engine"
+mce_namespace: "multicluster-engine"
+mce_create_idms: ""

--- a/test/playbooks/roles/mce_olm_install/tasks/main.yaml
+++ b/test/playbooks/roles/mce_olm_install/tasks/main.yaml
@@ -1,0 +1,281 @@
+---
+- name: Resolve effective IDMS flag
+  ansible.builtin.set_fact:
+    effective_create_idms: >-
+      {{ mce_create_idms if mce_create_idms != ''
+         else (mce_catalog_image != '') | string | lower }}
+
+- name: Resolve effective catalog source name
+  ansible.builtin.set_fact:
+    effective_catalog_source: >-
+      {{ 'mce-custom-catalog' if mce_catalog_image != ''
+         else 'redhat-operators' }}
+
+- name: Display MCE installation mode
+  ansible.builtin.debug:
+    msg: >-
+      MCE catalog: {{ 'custom (' ~ mce_catalog_image ~ ')' if mce_catalog_image != '' else 'redhat-operators (production)' }},
+      Channel: {{ mce_channel }},
+      IDMS: {{ effective_create_idms }}
+
+# Custom catalog setup (nightly/staging builds)
+
+- name: Create custom CatalogSource
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        name: mce-custom-catalog
+        namespace: openshift-marketplace
+      spec:
+        sourceType: grpc
+        image: "{{ mce_catalog_image }}"
+        displayName: MCE Custom Catalog
+        updateStrategy:
+          registryPoll:
+            interval: 10m
+  when: mce_catalog_image != ''
+
+- name: Wait for custom CatalogSource to be ready
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: mce-custom-catalog
+    namespace: openshift-marketplace
+  register: catalog_status
+  until: >-
+    catalog_status.resources is defined and
+    catalog_status.resources | length > 0 and
+    catalog_status.resources[0].status.connectionState.lastObservedState | default('') == 'READY'
+  retries: "{{ medium_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+  when: mce_catalog_image != ''
+
+- name: Create ImageDigestMirrorSet for downstream images
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: ImageDigestMirrorSet
+      metadata:
+        name: mce-downstream-mirror
+      spec:
+        imageDigestMirrors:
+          - mirrors:
+              - quay.io/acm-d
+            source: registry.redhat.io/multicluster-engine
+          - mirrors:
+              - quay.io/acm-d
+            source: registry.redhat.io/rhacm2
+  when: effective_create_idms | bool
+
+# MCE operator installation via OLM
+
+- name: Create MCE namespace
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Namespace
+    name: "{{ mce_namespace }}"
+    state: present
+
+- name: Create OperatorGroup for MCE
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: mce-operator-group
+        namespace: "{{ mce_namespace }}"
+      spec:
+        targetNamespaces:
+          - "{{ mce_namespace }}"
+
+- name: Create MCE Subscription
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: multicluster-engine
+        namespace: "{{ mce_namespace }}"
+      spec:
+        channel: "{{ mce_channel }}"
+        installPlanApproval: Automatic
+        name: "{{ mce_package_name }}"
+        source: "{{ effective_catalog_source }}"
+        sourceNamespace: openshift-marketplace
+
+- name: Wait for MCE CSV to succeed
+  ansible.builtin.shell: >-
+    kubectl get csv -n {{ mce_namespace }}
+    -o jsonpath='{.items[?(@.spec.displayName=="multicluster engine for Kubernetes")].status.phase}'
+    2>/dev/null
+  register: csv_status
+  until: csv_status.stdout == 'Succeeded'
+  retries: "{{ high_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+  changed_when: false
+
+# MCE CR and component deployment
+
+- name: Deploy MultiClusterEngine CR
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: multicluster.openshift.io/v1
+      kind: MultiClusterEngine
+      metadata:
+        name: multiclusterengine
+      spec:
+        overrides:
+          components:
+            - name: assisted-service
+              enabled: true
+            - name: cluster-api
+              enabled: true
+            - name: cluster-api-provider-metal3-preview
+              enabled: true
+            - name: cluster-api-provider-openshift-assisted-preview
+              enabled: true
+            - name: cluster-manager
+              enabled: true
+            - name: cluster-lifecycle
+              enabled: false
+            - name: server-foundation
+              enabled: false
+            - name: local-cluster
+              enabled: false
+            - name: console-mce
+              enabled: false
+            - name: hypershift
+              enabled: false
+            - name: hypershift-local-hosting
+              enabled: false
+            - name: discovery
+              enabled: false
+            - name: hive
+              enabled: false
+            - name: cluster-proxy-addon
+              enabled: false
+            - name: managedserviceaccount
+              enabled: false
+            - name: cluster-api-provider-aws
+              enabled: false
+            - name: image-based-install-operator
+              enabled: false
+        targetNamespace: "{{ mce_namespace }}"
+
+- name: Wait for MCE operator
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: multicluster-engine-operator
+    namespace: "{{ mce_namespace }}"
+  register: mce_operator_status
+  until: >-
+    mce_operator_status.resources is defined and
+    mce_operator_status.resources | length > 0 and
+    mce_operator_status.resources[0].status.conditions |
+    selectattr('type', 'equalto', 'Available') |
+    selectattr('status', 'equalto', 'True') |
+    list |
+    length > 0
+  retries: "{{ high_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+
+- name: Wait for AgentServiceConfig CRD to be available
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: agentserviceconfigs.agent-install.openshift.io
+  register: asc_crd_status
+  until: >-
+    asc_crd_status.resources is defined and
+    asc_crd_status.resources | length > 0
+  retries: "{{ high_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+
+- name: Generate OCP AgentServiceConfig manifest
+  ansible.builtin.template:
+    src: ocp-agentconfig.yaml.j2
+    dest: /tmp/ocp-agentconfig.yaml
+    mode: '0644'
+
+- name: Deploy AgentServiceConfig for OCP
+  kubernetes.core.k8s:
+    state: present
+    src: /tmp/ocp-agentconfig.yaml
+
+- name: Wait for assisted-service
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: assisted-service
+    namespace: "{{ mce_namespace }}"
+  register: assisted_service_status
+  until: >-
+    assisted_service_status.resources is defined and
+    assisted_service_status.resources | length > 0 and
+    assisted_service_status.resources[0].status.conditions |
+    selectattr('type', 'equalto', 'Available') |
+    selectattr('status', 'equalto', 'True') |
+    list |
+    length > 0
+  retries: "{{ high_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+
+- name: Wait for CAPI controller
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ mce_namespace }}"
+    label_selectors:
+      - "cluster.x-k8s.io/provider=cluster-api"
+  register: capi_status
+  until: >-
+    capi_status.resources is defined and
+    capi_status.resources | length > 0 and
+    capi_status.resources[0].status.conditions |
+    selectattr('type', 'equalto', 'Available') |
+    selectattr('status', 'equalto', 'True') |
+    list |
+    length > 0
+  retries: "{{ high_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+
+- name: Wait for Metal3Cluster CRD
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: metal3clusters.infrastructure.cluster.x-k8s.io
+    wait: true
+    wait_condition:
+      type: Established
+      status: "True"
+    wait_timeout: 300
+
+- name: Get assisted-service route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: "{{ mce_namespace }}"
+    label_selectors:
+      - "app=assisted-service"
+  register: assisted_route
+  until: >-
+    assisted_route.resources is defined and
+    assisted_route.resources | length > 0
+  retries: "{{ medium_retries | int }}"
+  delay: "{{ medium_delay | int }}"
+
+- name: Set assisted service hostname fact
+  ansible.builtin.set_fact:
+    assisted_service_hostname: "{{ assisted_route.resources[0].spec.host }}"
+
+- name: Display assisted service route
+  ansible.builtin.debug:
+    msg: "Assisted service available at: https://{{ assisted_service_hostname }}"

--- a/test/playbooks/roles/mce_olm_install/templates/ocp-agentconfig.yaml.j2
+++ b/test/playbooks/roles/mce_olm_install/templates/ocp-agentconfig.yaml.j2
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: assisted-installer-config-override
+  namespace: {{ mce_namespace }}
+data:
+  INSTALL_TO_EXISTING_ROOT: "true"
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: AgentServiceConfig
+metadata:
+  name: agent
+  annotations:
+    unsupported.agent-install.openshift.io/assisted-service-configmap: "assisted-installer-config-override"
+spec:
+  databaseStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "10Gi"
+  filesystemStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "10Gi"
+  osImages: []

--- a/test/playbooks/roles/ocp_cluster_setup/defaults/main.yaml
+++ b/test/playbooks/roles/ocp_cluster_setup/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+ocp_kubeconfig_path: ""
+ocp_cluster_domain: ""
+ocp_router_ip: ""

--- a/test/playbooks/roles/ocp_cluster_setup/tasks/main.yaml
+++ b/test/playbooks/roles/ocp_cluster_setup/tasks/main.yaml
@@ -1,0 +1,101 @@
+---
+- name: Check if kubectl is installed
+  ansible.builtin.command: kubectl version --client
+  register: kubectl_check
+  changed_when: false
+  failed_when: false
+
+- name: Get latest kubectl version  # noqa: command-instead-of-module
+  ansible.builtin.command: >
+    curl -4 -sL --fail --retry 5 --retry-delay 5 --max-time 30
+    https://dl.k8s.io/release/stable.txt
+  register: stable_kubectl_version
+  changed_when: false
+  when: kubectl_check.rc != 0
+
+- name: Install kubectl binary  # noqa: command-instead-of-module no-changed-when
+  ansible.builtin.command:
+    cmd: >-
+      curl -4 -fsSL -o /usr/local/bin/kubectl
+      "https://dl.k8s.io/release/{{ stable_kubectl_version.stdout | trim }}/bin/linux/amd64/kubectl"
+  when: kubectl_check.rc != 0
+
+- name: Set kubectl permissions
+  ansible.builtin.file:
+    path: /usr/local/bin/kubectl
+    mode: '0755'
+  when: kubectl_check.rc != 0
+
+- name: Copy external OCP kubeconfig to remote host
+  ansible.builtin.copy:
+    src: "{{ ocp_kubeconfig_path }}"
+    dest: /tmp/ocp-kubeconfig
+    mode: '0600'
+  when: ocp_kubeconfig_path != ''
+
+- name: Validate OCP cluster connectivity
+  ansible.builtin.command: kubectl cluster-info
+  register: cluster_info
+  changed_when: false
+
+- name: Discover OCP apps domain
+  ansible.builtin.command: >-
+    kubectl get ingresses.config.openshift.io cluster
+    -o jsonpath='{.spec.domain}'
+  register: apps_domain_result
+  changed_when: false
+  when: ocp_cluster_domain == ''
+
+- name: Set OCP apps domain fact
+  ansible.builtin.set_fact:
+    ocp_apps_domain: >-
+      {{ ocp_cluster_domain if ocp_cluster_domain != ''
+         else apps_domain_result.stdout }}
+
+- name: Discover OCP router IP from router service
+  ansible.builtin.command: >-
+    kubectl get svc -n openshift-ingress router-default
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+  register: router_svc_result
+  changed_when: false
+  failed_when: false
+  when: ocp_router_ip == ''
+
+- name: Fallback - discover OCP router IP from worker node
+  ansible.builtin.command: >-
+    kubectl get nodes -l node-role.kubernetes.io/worker
+    -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'
+  register: router_node_result
+  changed_when: false
+  when: >-
+    ocp_router_ip == '' and
+    (router_svc_result.stdout | default('') | trim == '')
+
+- name: Set OCP router IP fact
+  ansible.builtin.set_fact:
+    ocp_router_ip: >-
+      {{ ocp_router_ip if ocp_router_ip != ''
+         else (router_svc_result.stdout | trim
+               if router_svc_result.stdout | default('') | trim != ''
+               else router_node_result.stdout | trim) }}
+
+- name: Display OCP cluster info
+  ansible.builtin.debug:
+    msg: "OCP apps domain: {{ ocp_apps_domain }}, Router IP: {{ ocp_router_ip }}"
+
+- name: Verify OLM is running
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: catalog-operator
+    namespace: openshift-operator-lifecycle-manager
+  register: olm_status
+  until: >-
+    olm_status.resources is defined and
+    olm_status.resources | length > 0
+
+- name: Write router IP for bmh_setup consumption
+  ansible.builtin.copy:
+    content: "{{ ocp_router_ip }}"
+    dest: /tmp/loadbalancer_ip
+    mode: '0644'

--- a/test/playbooks/run_test_ocp.yaml
+++ b/test/playbooks/run_test_ocp.yaml
@@ -1,0 +1,124 @@
+---
+# Setup and run tests on an OCP management cluster with MCE via OLM
+#
+# This playbook deploys an OCP cluster via dev-scripts on a bare-metal host,
+# installs MCE via OLM, then provisions a workload cluster using CAPOA with
+# emulated bare-metal nodes (libvirt VMs + sushy-tools).
+#
+# Environment variables:
+#   PULLSECRET=<base64>        - Base64-encoded container registry pull secret (required)
+#   OCP_TOPOLOGY=compact       - OCP management cluster topology: compact, ha, sno
+#   OCP_VERSION=4.20           - OCP release stream for dev-scripts
+#   OCP_RELEASE_IMAGE=<image>  - Specific OCP release image (overrides OCP_VERSION)
+#   MCE_CATALOG_IMAGE=<image>  - Custom catalog index image (omit for production redhat-operators)
+#   MCE_CHANNEL=stable-2.11    - OLM subscription channel
+#   MCE_NAMESPACE=<ns>         - MCE namespace (default: multicluster-engine)
+#   MCE_CREATE_IDMS=true       - Create ImageDigestMirrorSet (auto when custom catalog)
+#   SKIP_OCP_INSTALL=true      - Skip OCP deployment (provide OCP_KUBECONFIG_PATH instead)
+#   OCP_KUBECONFIG_PATH=<path> - Path to existing OCP kubeconfig (when SKIP_OCP_INSTALL=true)
+#   SKIP_MCE_INSTALL=true      - Skip MCE installation (assume pre-installed)
+#   SKIP_CLUSTER=true          - Skip workload cluster provisioning and assertions
+#
+# Examples:
+#   # Full e2e: deploy OCP, install MCE, provision workload cluster
+#   make e2e-test-ocp
+#
+#   # Use a specific OCP release image
+#   OCP_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.20.0-x86_64 \
+#     make e2e-test-ocp
+#
+#   # Test with a nightly MCE build
+#   MCE_CATALOG_IMAGE=quay.io/acm-d/mce-custom-registry:2.11-BACKPLANE-2025-07-15-00-26-11 \
+#     make e2e-test-ocp
+#
+#   # Skip OCP deploy, use existing cluster
+#   SKIP_OCP_INSTALL=true OCP_KUBECONFIG_PATH=~/.kube/ocp-config \
+#     make e2e-test-ocp
+#
+#   # Skip OCP + MCE install, just provision workload cluster
+#   SKIP_OCP_INSTALL=true OCP_KUBECONFIG_PATH=~/.kube/ocp-config \
+#     SKIP_MCE_INSTALL=true make e2e-test-ocp
+
+- name: Setup and run tests on OCP management cluster
+  hosts: test_runner
+  vars:
+    management_cluster_type: ocp
+    remote_manifests_path: /tmp/manifests
+    test_namespace: test-capi
+    number_of_nodes: "{{ lookup('ansible.builtin.env', 'NUMBER_OF_NODES', default='7') }}"
+    cluster_topology: "{{ lookup('ansible.builtin.env', 'CLUSTER_TOPOLOGY', default='multinode') }}"
+    example_manifest: "{{ cluster_topology }}-example.yaml.j2"
+    src_dir: "/tmp/capbcoa"
+    ssh_authorized_key: "{{ lookup('ansible.builtin.env', 'SSH_AUTHORIZED_KEY') }}"
+    pullsecret: "{{ lookup('ansible.builtin.env', 'PULLSECRET') }}"
+    cluster_name: "test-{{ cluster_topology }}"
+    medium_delay: 10
+    medium_retries: 60
+    high_delay: 60
+    high_retries: 300
+    low_delay: 1
+    low_retries: 1
+    extra_paths:
+      - /usr/local/bin
+    openshift_version: >-
+      {{ lookup('ansible.builtin.env', 'OPENSHIFT_VERSION') | default('4.20.0', true) }}
+    default_rhcos_image_url: >-
+      https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.20/4.20.0/rhcos-4.20.0-x86_64-nutanix.x86_64.qcow2
+    rhcos_image_url: >-
+      {{ lookup('ansible.builtin.env', 'RHCOS_IMAGE_URL') | default(default_rhcos_image_url, true) }}
+    rhcos_checksum_url: >-
+      {{ lookup('ansible.builtin.env', 'RHCOS_CHECKSUM_URL')
+         | default(rhcos_image_url | dirname ~ '/sha256sum.txt', true) }}
+
+    # OCP management cluster deployment
+    dev_scripts_topology: "{{ lookup('ansible.builtin.env', 'OCP_TOPOLOGY', default='compact') }}"
+    dev_scripts_ocp_version: "{{ lookup('ansible.builtin.env', 'OCP_VERSION', default='4.20') }}"
+    dev_scripts_release_image: "{{ lookup('ansible.builtin.env', 'OCP_RELEASE_IMAGE', default='') }}"
+    skip_ocp_install: "{{ lookup('ansible.builtin.env', 'SKIP_OCP_INSTALL', default='false') | lower in ['true', '1', 'yes'] }}"
+    ocp_kubeconfig_path: "{{ lookup('ansible.builtin.env', 'OCP_KUBECONFIG_PATH', default='') }}"
+    ocp_cluster_domain: "{{ lookup('ansible.builtin.env', 'OCP_CLUSTER_DOMAIN', default='') }}"
+    ocp_router_ip: "{{ lookup('ansible.builtin.env', 'OCP_ROUTER_IP', default='') }}"
+
+    # MCE OLM configuration
+    mce_catalog_image: "{{ lookup('ansible.builtin.env', 'MCE_CATALOG_IMAGE', default='') }}"
+    mce_channel: "{{ lookup('ansible.builtin.env', 'MCE_CHANNEL', default='stable-2.11') }}"
+    mce_package_name: "{{ lookup('ansible.builtin.env', 'MCE_PACKAGE_NAME', default='multicluster-engine') }}"
+    mce_namespace: "{{ lookup('ansible.builtin.env', 'MCE_NAMESPACE', default='multicluster-engine') }}"
+    mce_create_idms: "{{ lookup('ansible.builtin.env', 'MCE_CREATE_IDMS', default='') }}"
+
+    # Conditional execution flags
+    skip_mce_install: "{{ lookup('ansible.builtin.env', 'SKIP_MCE_INSTALL', default='false') | lower in ['true', '1', 'yes'] }}"
+    skip_cluster: "{{ lookup('ansible.builtin.env', 'SKIP_CLUSTER', default='false') | lower in ['true', '1', 'yes'] }}"
+
+  environment:
+    PATH: "{{ extra_paths | join(':') }}:{{ ansible_env.PATH }}"
+    KUBECONFIG: /tmp/ocp-kubeconfig
+
+  roles:
+    # Infrastructure setup (always runs)
+    - system_dependencies
+    - sourcecode_setup
+    - network_setup
+    - baremetal_emulation
+
+    # OCP management cluster deployment via dev-scripts
+    - role: dev_scripts_setup
+      when: not skip_ocp_install
+
+    # OCP cluster validation and discovery
+    - ocp_cluster_setup
+
+    # MCE installation via OLM
+    - role: mce_olm_install
+      when: not skip_mce_install
+
+    # BMH setup (always runs)
+    - bmh_setup
+
+    # Workload cluster provisioning
+    - role: cluster_install
+      when: not skip_cluster
+    - role: assert_install
+      when: not skip_cluster
+    - role: assert_upgrade
+      when: not skip_cluster and upgrade_to_version is defined


### PR DESCRIPTION
Add a test playbook covering the OCP delivery case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OpenShift-specific end-to-end test support, including cluster discovery, MCE installation, bare-metal setup, and optional cluster provisioning.
  - Added automated cleanup for OpenShift test resources, operators, namespaces, virtual machines, and networks.
  - Added support for custom MCE catalogs and image mirror configuration.

- **Documentation**
  - Documented OpenShift test prerequisites, configuration options, execution modes, and cleanup procedures.
  - Added instructions for running tests against an existing OpenShift cluster.

- **Bug Fixes**
  - Improved DNS handling for OpenShift application domains during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->