### PR TITLE
NO-ISSUE: Fix security scan workflow to use pull_request trigger

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -3,7 +3,12 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
 
 jobs:
   image-scan:
@@ -19,8 +24,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -50,8 +53,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Create scans folder
         run: mkdir -p scans/
       - name: Run Trivy vulnerability scanner in repo mode


### PR DESCRIPTION
Switch pull_request_target → pull_request to fix actions/checkout@v4 blocking fork PR checkouts. Add explicit permissions block (security-events: write, contents: read). Remove unnecessary ref: overrides from checkout steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Security scans now run on pull request events and can also be started manually.
  * Updated workflow permissions to support security reporting and repository access.
  * Improved source checkout behavior during security scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->