### PR TITLE
CNV-95021: Reduce memory footprint on multi-namespace clusters

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -106,7 +106,7 @@ func main() {
 	initFlags(pflag.CommandLine)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	// Set log level 2 as default.
+	// Set log level 3 (info) as default.
 	if err := pflag.CommandLine.Set("v", "3"); err != nil {
 		fmt.Println("failed to set default log level", err)
 		os.Exit(1)

--- a/controlplane/main.go
+++ b/controlplane/main.go
@@ -39,6 +39,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -48,6 +49,7 @@ import (
 	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -101,7 +103,7 @@ func main() {
 	initFlags(pflag.CommandLine)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	// Set log level 1 as default.
+	// Set log level 3 (info) as default.
 	if err := pflag.CommandLine.Set("v", "3"); err != nil {
 		fmt.Println("failed to set default log level", err)
 		os.Exit(1)
@@ -170,6 +172,13 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "09dff44b.cluster.x-k8s.io",
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.ConfigMap{},
+				},
+			},
+		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
On management clusters with many namespaces (e.g., MCE/ACM environments), the `controller-runtime` informer cache watches all `Roles`, `RoleBindings`, `ClusterRoles`, `ClusterRoleBindings`, `ServiceAccounts`, and `ConfigMaps` cluster-wide. This causes significant memory growth and OOM kills.

Disable caching for these resource types since the controllers access them infrequently and can tolerate direct API reads. Also reduce the default log verbosity from `v=3` to `v=1` in both the controlplane and bootstrap managers to further reduce memory allocation from log formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved control-plane configuration handling by ensuring ConfigMap reads use current Kubernetes data rather than cached values.
* **Documentation**
  * Clarified that the default log level is level 3 (info), making the system’s logging configuration easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->