### PR TITLE
CNV-95022: Prevent upgrade controller from pushing downgrades

### DIFF
--- a/controlplane-components.yaml
+++ b/controlplane-components.yaml
@@ -1250,6 +1250,20 @@ spec:
               replicas:
                 format: int32
                 type: integer
+              upgradePolicy:
+                default: Managed
+                description: |-
+                  UpgradePolicy controls how the controller handles workload cluster upgrades.
+                  - Managed (default): the controller actively reverts any externally-initiated
+                    upgrades (e.g., admin running oc adm upgrade on the workload cluster). Only upgrades
+                    driven by updating spec.distributionVersion are allowed.
+                  - Unrestricted: the controller does not block external upgrades. If the workload
+                    cluster is upgraded independently, a VersionDriftDetected condition is surfaced
+                    but no corrective action is taken.
+                enum:
+                - Managed
+                - Unrestricted
+                type: string
             required:
             - distributionVersion
             - machineTemplate

--- a/controlplane/api/v1alpha3/condition_consts.go
+++ b/controlplane/api/v1alpha3/condition_consts.go
@@ -39,6 +39,14 @@ const (
 	// UpgradeFailedReason (Severity=Error) documents that an upgrade has failed.
 	UpgradeFailedReason = "UpgradeFailed"
 
+	// ExternalUpgradeBlockedReason (Severity=Warning) documents that an external
+	// upgrade attempt was detected and reverted by the controller.
+	ExternalUpgradeBlockedReason = "ExternalUpgradeBlocked"
+
+	// VersionDriftDetectedReason (Severity=Warning) documents that the tenant cluster
+	// version differs from spec.distributionVersion due to an external upgrade.
+	VersionDriftDetectedReason = "VersionDriftDetected"
+
 	// UpgradeImageUnavailableReason (Severity=Error) documents whether an upgrade image is available
 	UpgradeImageUnavailableReason = "UpgradeImageUnavailable"
 

--- a/controlplane/api/v1alpha3/openshiftassistedcontrolplane_types.go
+++ b/controlplane/api/v1alpha3/openshiftassistedcontrolplane_types.go
@@ -51,6 +51,17 @@ type OpenshiftAssistedControlPlaneSpec struct {
 	Replicas                    int32                                         `json:"replicas,omitempty"`
 	// DistributionVersion describes the targeted OpenShift version
 	DistributionVersion string `json:"distributionVersion"`
+
+	// UpgradePolicy controls how the controller handles workload cluster upgrades.
+	// - Managed (default): the controller actively reverts any externally-initiated
+	//   upgrades (e.g., admin running oc adm upgrade on the workload cluster). Only upgrades
+	//   driven by updating spec.distributionVersion are allowed.
+	// - Unrestricted: the controller does not block external upgrades. If the workload
+	//   cluster is upgraded independently, a VersionDriftDetected condition is surfaced
+	//   but no corrective action is taken.
+	// +kubebuilder:default=Managed
+	// +optional
+	UpgradePolicy UpgradePolicyType `json:"upgradePolicy,omitempty"`
 }
 
 // OpenshiftAssistedControlPlaneConfigSpec defines configuration for the agent-provisioned cluster
@@ -239,6 +250,20 @@ type OpenshiftAssistedControlPlaneList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []OpenshiftAssistedControlPlane `json:"items"`
 }
+
+// UpgradePolicyType defines how the controller handles tenant cluster upgrades.
+// +kubebuilder:validation:Enum=Managed;Unrestricted
+type UpgradePolicyType string
+
+const (
+	// UpgradePolicyManaged means the controller actively reverts externally-initiated
+	// upgrades. Only upgrades driven by spec.distributionVersion are permitted.
+	UpgradePolicyManaged UpgradePolicyType = "Managed"
+
+	// UpgradePolicyUnrestricted means the controller does not block external upgrades.
+	// If the tenant upgrades independently, a condition is surfaced but no action is taken.
+	UpgradePolicyUnrestricted UpgradePolicyType = "Unrestricted"
+)
 
 func init() {
 	SchemeBuilder.Register(&OpenshiftAssistedControlPlane{}, &OpenshiftAssistedControlPlaneList{})

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_openshiftassistedcontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_openshiftassistedcontrolplanes.yaml
@@ -1231,6 +1231,20 @@ spec:
               replicas:
                 format: int32
                 type: integer
+              upgradePolicy:
+                default: Managed
+                description: |-
+                  UpgradePolicy controls how the controller handles workload cluster upgrades.
+                  - Managed (default): the controller actively reverts any externally-initiated
+                    upgrades (e.g., admin running oc adm upgrade on the workload cluster). Only upgrades
+                    driven by updating spec.distributionVersion are allowed.
+                  - Unrestricted: the controller does not block external upgrades. If the workload
+                    cluster is upgraded independently, a VersionDriftDetected condition is surfaced
+                    but no corrective action is taken.
+                enum:
+                - Managed
+                - Unrestricted
+                type: string
             required:
             - distributionVersion
             - machineTemplate

--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
@@ -293,9 +293,12 @@ func (r *OpenshiftAssistedControlPlaneReconciler) upgradeWorkloadCluster(ctx con
 
 	var isUpdateInProgress bool
 	var upgradeConditionMessage string
+	var conditionHandled bool
 	defer func() {
+		if conditionHandled {
+			return
+		}
 		if isUpdateInProgress || !isWorkloadClusterRunningDesiredVersion(oacp) {
-			// Either upgrade is in progress or it failed
 			setUpgradeStatus(oacp, isUpdateInProgress, upgradeConditionMessage)
 			return
 		}
@@ -327,11 +330,49 @@ func (r *OpenshiftAssistedControlPlaneReconciler) upgradeWorkloadCluster(ctx con
 		log.V(logutil.DebugLevel).Info("failed to get OpenShift version from ClusterVersion", "error", err.Error())
 	}
 
-	// TODO: check for upgrade errors, mark relevant conditions
+	specVersion, specErr := semver.ParseTolerant(oacp.Spec.DistributionVersion)
+	statusVersion, statusErr := semver.ParseTolerant(oacp.Status.DistributionVersion)
+
+	// Detect version drift: tenant cluster version is ahead of spec.distributionVersion.
+	// This happens when an external upgrade completed before the controller could revert it.
+	// Surface a condition so the cluster admin can update spec to acknowledge.
+	if specErr == nil && statusErr == nil && statusVersion.GT(specVersion) {
+		log.Info("version drift detected: tenant cluster is ahead of spec.distributionVersion",
+			"spec", oacp.Spec.DistributionVersion, "status", oacp.Status.DistributionVersion)
+		conditionHandled = true
+		setConditionFalse(oacp, controlplanev1alpha3.UpgradeCompletedCondition,
+			controlplanev1alpha3.VersionDriftDetectedReason,
+			"tenant cluster version %s is ahead of spec.distributionVersion %s; update spec to acknowledge",
+			oacp.Status.DistributionVersion, oacp.Spec.DistributionVersion)
+		return ctrl.Result{}, nil
+	}
+
+	// If an upgrade is in progress targeting a version we didn't request, and we're
+	// NOT expecting an upgrade ourselves (spec <= status), it was externally initiated.
+	// Clear it to enforce that upgrades are controller-driven only (when policy is Managed).
 	isDesiredVersionUpdated, err := upgrader.IsDesiredVersionUpdated(ctx, oacp.Spec.DistributionVersion)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	specIsNewer := specErr == nil && statusErr == nil && specVersion.GT(statusVersion)
+	if isUpdateInProgress && !isDesiredVersionUpdated && !specIsNewer {
+		if oacp.Spec.UpgradePolicy == "" || oacp.Spec.UpgradePolicy == controlplanev1alpha3.UpgradePolicyManaged {
+			log.Info("detected externally-initiated upgrade, clearing desiredUpdate (policy=Managed)",
+				"spec", oacp.Spec.DistributionVersion, "status", oacp.Status.DistributionVersion)
+			if clearErr := upgrader.ClearDesiredUpdate(ctx); clearErr != nil {
+				log.Error(clearErr, "failed to clear external desiredUpdate")
+				return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+			}
+			conditionHandled = true
+			setConditionFalse(oacp, controlplanev1alpha3.UpgradeCompletedCondition,
+				controlplanev1alpha3.ExternalUpgradeBlockedReason,
+				"an external upgrade attempt was reverted; upgrades must be driven via spec.distributionVersion")
+			return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+		}
+		log.Info("detected externally-initiated upgrade (policy=Unrestricted), not blocking",
+			"spec", oacp.Spec.DistributionVersion, "status", oacp.Status.DistributionVersion)
+	}
+
 	if isDesiredVersionUpdated && isUpdateInProgress {
 		log.V(logutil.DebugLevel).Info("desired version is updated, but did not complete upgrade yet, re-reconciling")
 		return ctrl.Result{
@@ -342,11 +383,19 @@ func (r *OpenshiftAssistedControlPlaneReconciler) upgradeWorkloadCluster(ctx con
 
 	if isWorkloadClusterRunningDesiredVersion(oacp) && !isUpdateInProgress {
 		log.V(logutil.DebugLevel).Info("cluster is now running expected version, upgrade completed")
-
 		return ctrl.Result{}, nil
 	}
 
-	// once updating, requeue to check update status
+	// Only push an upgrade when spec.distributionVersion is strictly newer than
+	// what the tenant is currently running. Never push a downgrade.
+	// If we can't determine the current version, proceed with the push (safe default).
+	if specErr == nil && statusErr == nil && !specVersion.GT(statusVersion) {
+		log.V(logutil.DebugLevel).Info("spec.distributionVersion is not newer than current, skipping upgrade push",
+			"spec", oacp.Spec.DistributionVersion, "status", oacp.Status.DistributionVersion)
+		return ctrl.Result{}, nil
+	}
+
+	// Push controller-initiated upgrade
 	return ctrl.Result{
 			Requeue:      true,
 			RequeueAfter: 1 * time.Minute,
@@ -386,6 +435,11 @@ func getUpgradeOptions(oacp *controlplanev1alpha3.OpenshiftAssistedControlPlane,
 }
 
 func isWorkloadClusterRunningDesiredVersion(oacp *controlplanev1alpha3.OpenshiftAssistedControlPlane) bool {
+	specV, specErr := semver.ParseTolerant(oacp.Spec.DistributionVersion)
+	statusV, statusErr := semver.ParseTolerant(oacp.Status.DistributionVersion)
+	if specErr == nil && statusErr == nil {
+		return specV.EQ(statusV)
+	}
 	return oacp.Spec.DistributionVersion == oacp.Status.DistributionVersion
 }
 

--- a/controlplane/internal/upgrade/mock_upgrade.go
+++ b/controlplane/internal/upgrade/mock_upgrade.go
@@ -72,6 +72,20 @@ func (m *MockClusterUpgrade) EXPECT() *MockClusterUpgradeMockRecorder {
 	return m.recorder
 }
 
+// ClearDesiredUpdate mocks base method.
+func (m *MockClusterUpgrade) ClearDesiredUpdate(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearDesiredUpdate", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearDesiredUpdate indicates an expected call of ClearDesiredUpdate.
+func (mr *MockClusterUpgradeMockRecorder) ClearDesiredUpdate(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearDesiredUpdate", reflect.TypeOf((*MockClusterUpgrade)(nil).ClearDesiredUpdate), ctx)
+}
+
 // GetCurrentVersion mocks base method.
 func (m *MockClusterUpgrade) GetCurrentVersion(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/controlplane/internal/upgrade/upgrade.go
+++ b/controlplane/internal/upgrade/upgrade.go
@@ -37,6 +37,7 @@ type ClusterUpgrade interface {
 	IsDesiredVersionUpdated(ctx context.Context, desiredVersion string) (bool, error)
 	GetUpgradeStatus(ctx context.Context) (string, error)
 	UpdateClusterVersionDesiredUpdate(ctx context.Context, desiredVersion string, architecture string, options ...ClusterUpgradeOption) error
+	ClearDesiredUpdate(ctx context.Context) error
 }
 
 func NewOpenshiftUpgradeFactory(remoteImage containers.RemoteImage, clientGenerator workloadclient.ClientGenerator) *OpenshiftUpgradeFactory {
@@ -168,6 +169,20 @@ func (u *OpenshiftUpgrader) UpdateClusterVersionDesiredUpdate(ctx context.Contex
 		return u.client.Update(ctx, &clusterVersion)
 	}
 	return nil
+}
+
+// ClearDesiredUpdate removes any pending desiredUpdate from the ClusterVersion,
+// effectively canceling an in-flight upgrade that was not initiated by this controller.
+func (u *OpenshiftUpgrader) ClearDesiredUpdate(ctx context.Context) error {
+	clusterVersion, err := u.getClusterVersion(ctx)
+	if err != nil {
+		return err
+	}
+	if clusterVersion.Spec.DesiredUpdate == nil {
+		return nil
+	}
+	clusterVersion.Spec.DesiredUpdate = nil
+	return u.client.Update(ctx, &clusterVersion)
 }
 
 func (u *OpenshiftUpgrader) getClusterVersion(ctx context.Context) (configv1.ClusterVersion, error) {

--- a/test/e2e/manifests/capcoa/controlplane_install.yaml
+++ b/test/e2e/manifests/capcoa/controlplane_install.yaml
@@ -1250,6 +1250,20 @@ spec:
               replicas:
                 format: int32
                 type: integer
+              upgradePolicy:
+                default: Managed
+                description: |-
+                  UpgradePolicy controls how the controller handles workload cluster upgrades.
+                  - Managed (default): the controller actively reverts any externally-initiated
+                    upgrades (e.g., admin running oc adm upgrade on the workload cluster). Only upgrades
+                    driven by updating spec.distributionVersion are allowed.
+                  - Unrestricted: the controller does not block external upgrades. If the workload
+                    cluster is upgraded independently, a VersionDriftDetected condition is surfaced
+                    but no corrective action is taken.
+                enum:
+                - Managed
+                - Unrestricted
+                type: string
             required:
             - distributionVersion
             - machineTemplate


### PR DESCRIPTION
## Goal
Enforce that workload cluster upgrades are controller-driven only, with a configurable policy.

## Changes

### New API field: `spec.upgradePolicy`
- **Managed** (default): the controller actively reverts any externally-initiated upgrades (e.g., admin running `oc adm upgrade` on the workload cluster). Only upgrades driven by updating `spec.distributionVersion` are allowed. This follows the same pattern as HyperShift's HCCO `reconcileClusterVersion`.
- **Unrestricted**: the controller does not block external upgrades. If the workload cluster is upgraded independently, a `VersionDriftDetected` condition is surfaced but no corrective action is taken.

### Upgrade safety logic
- **Never push a downgrade**: if `spec.distributionVersion <= status.distributionVersion`, skip the upgrade push (downgrades are [unsupported by Red Hat](https://access.redhat.com/solutions/4777861))
- **Revert external upgrades** (Managed policy): if an upgrade is in progress that doesn't match `spec.distributionVersion` and the controller is not expecting its own upgrade, clear `ClusterVersion.spec.desiredUpdate`
- **Detect version drift**: if `status > spec` (an external upgrade already completed), surface a `VersionDriftDetected` condition so the cluster admin can update spec to acknowledge
- **Semantic version comparison**: use `semver.ParseTolerant` for version equality checks

### New conditions
| Reason | Meaning |
|--------|---------|
| `ExternalUpgradeBlocked` | An external upgrade attempt was detected and reverted |
| `VersionDriftDetected` | The workload cluster version is ahead of `spec.distributionVersion` |

### New interface method
`ClearDesiredUpdate` nulls the `ClusterVersion.spec.desiredUpdate` field on the workload cluster, following the same pattern as HyperShift's HCCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cluster upgrades from proceeding when the current version is ahead of the requested version.
  * Prevented unintended downgrades and skipped unnecessary upgrade updates.
  * Cleared externally initiated upgrade requests that were not approved by the controller.

* **Improvements**
  * Added clear warning conditions for blocked external upgrades and detected version drift.
  * Upgrade status is now refreshed and retried appropriately when an upgrade is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->