### PR TITLE
MGMT-24965: Add omitzero to embedded struct fields in v1alpha2/v1alpha3

### DIFF
--- a/bootstrap/api/v1alpha2/openshiftassistedconfigtemplate_types.go
+++ b/bootstrap/api/v1alpha2/openshiftassistedconfigtemplate_types.go
@@ -32,7 +32,7 @@ type OpenshiftAssistedConfigTemplateResource struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	ObjectMeta clusterv1.ObjectMeta `json:"metadata,omitempty"`
+	ObjectMeta clusterv1.ObjectMeta `json:"metadata,omitempty,omitzero"`
 
 	Spec OpenshiftAssistedConfigSpec `json:"spec,omitempty"`
 }

--- a/controlplane/api/v1alpha3/openshiftassistedcontrolplane_types.go
+++ b/controlplane/api/v1alpha3/openshiftassistedcontrolplane_types.go
@@ -30,7 +30,7 @@ type OpenshiftAssistedControlPlaneMachineTemplate struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	ObjectMeta clusterv1.ObjectMeta `json:"metadata,omitempty"`
+	ObjectMeta clusterv1.ObjectMeta `json:"metadata,omitempty,omitzero"`
 
 	// InfrastructureRef is a required reference to a custom resource
 	// offered by an infrastructure provider.
@@ -39,7 +39,7 @@ type OpenshiftAssistedControlPlaneMachineTemplate struct {
 	// Deletion contains configuration options for Machine deletion.
 	// +optional
 	// +kubebuilder:default={nodeDeletionTimeoutSeconds: 10}
-	Deletion clusterv1.MachineDeletionSpec `json:"deletion,omitempty"`
+	Deletion clusterv1.MachineDeletionSpec `json:"deletion,omitempty,omitzero"`
 }
 
 // OpenshiftAssistedControlPlaneSpec defines the desired state of OpenshiftAssistedControlPlane


### PR DESCRIPTION
clusterv1.ObjectMeta and clusterv1.MachineDeletionSpec carry MinProperties=1. omitempty does not omit zero-value structs — they serialize as {} and fail CRD validation with a 422. omitzero omits them entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization of optional metadata and deletion settings.
  * Prevented empty values from being included unnecessarily when configuration objects are encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->