### PR TITLE
NO-ISSUE: Limit golangci-lint concurrency to 2 to prevent OOM

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   allow-parallel-runners: true
+  concurrency: 2
 linters:
   default: none
   enable:


### PR DESCRIPTION
The lint CI job was OOMKilled after ~9 minutes. golangci-lint defaults concurrency to GOMAXPROCS, which causes multiple packages' full analysis state (AST, type graph, SSA) to coexist in memory simultaneously, exceeding the 4Gi container limit. Cap concurrency at 2 in .golangci.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited concurrent linting to improve consistency and resource usage during automated code checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->